### PR TITLE
Fix: Refine simplifies symmetric matrix element

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -34,7 +34,7 @@ If you wish to contribute to SymPy or like to get the latest updates as they
 come, install SymPy from git. To download the repository, execute the
 following from the command line::
 
-    git clone git://github.com/sympy/sympy.git
+    git clone https://github.com/sympy/sympy.git
 
 To update to the latest version, go into your repository and execute::
 

--- a/sympy/combinatorics/tests/test_graycode.py
+++ b/sympy/combinatorics/tests/test_graycode.py
@@ -1,7 +1,7 @@
 from sympy.combinatorics.graycode import (GrayCode, bin_to_gray,
     random_bitstring, get_subset_from_bitstring, graycode_subsets,
     gray_to_bin)
-
+from sympy.utilities.pytest import raises
 
 def test_graycode():
     g = GrayCode(2)
@@ -56,6 +56,11 @@ def test_graycode():
     assert list(graycode_subsets(['a', 'b', 'c'])) == \
         [[], ['c'], ['b', 'c'], ['b'], ['a', 'b'], ['a', 'b', 'c'],
     ['a', 'c'], ['a']]
+
+    raises(ValueError, lambda: GrayCode(0))
+    raises(ValueError, lambda: GrayCode(2.2))
+    raises(ValueError, lambda: GrayCode(2, start=[1, 1, 0]))
+    raises(ValueError, lambda: GrayCode(2, rank=2.5))
 
 def test_live_issue_117():
     assert bin_to_gray('0100') == '0110'

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -945,7 +945,8 @@ class Basic(with_metaclass(ManagedProperties)):
                 # when old is a string we prefer Symbol
                 s = Symbol(s[0]), s[1]
             try:
-                s = [sympify(_, strict=type(_) is not str) for _ in s]
+                s = [sympify(_, strict=not isinstance(_, string_types))
+                     for _ in s]
             except SympifyError:
                 # if it can't be sympified, skip it
                 sequence[i] = None

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3537,6 +3537,27 @@ def _n2(a, b):
             return dif
 
 
+def unchanged(func, *args):
+    """Return True if `func` applied to the `args` is unchanged.
+    Can be used instead of `assert foo == foo`.
+
+    Examples
+    ========
+
+    >>> from sympy.core.expr import unchanged
+    >>> from sympy.functions.elementary.trigonometric import cos
+    >>> from sympy.core.numbers import pi
+
+    >>> unchanged(cos, 1)  # instead of assert cos(1) == cos(1)
+    True
+
+    >>> unchanged(cos, pi)
+    False
+    """
+    f = func(*args)
+    return f.func == func and f.args == tuple([sympify(a) for a in args])
+
+
 from .mul import Mul
 from .add import Add
 from .power import Pow

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1551,7 +1551,10 @@ class Derivative(Expr):
         if hints.get('deep', True):
             expr = expr.doit(**hints)
         hints['evaluate'] = True
-        return self.func(expr, *self.variable_count, **hints)
+        rv = self.func(expr, *self.variable_count, **hints)
+        if rv!= self and rv.has(Derivative):
+            rv =  rv.doit(**hints)
+        return rv
 
     @_sympifyit('z0', NotImplementedError)
     def doit_numerically(self, z0):

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -203,7 +203,7 @@ class Logic(object):
         return self.args
 
     def __hash__(self):
-        return hash( (type(self).__name__,) + tuple(self.args) )
+        return hash((type(self).__name__,) + tuple(self.args))
 
     def __eq__(a, b):
         if not isinstance(b, type(a)):
@@ -232,7 +232,8 @@ class Logic(object):
         return (a > b) - (a < b)
 
     def __str__(self):
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(str(a) for a in self.args))
+        return '%s(%s)' % (self.__class__.__name__,
+                           ', '.join(str(a) for a in self.args))
 
     __repr__ = __str__
 
@@ -337,7 +338,7 @@ class And(AndOr_Base):
 
     def _eval_propagate_not(self):
         # !(a&b&c ...) == !a | !b | !c ...
-        return Or( *[Not(a) for a in self.args] )
+        return Or(*[Not(a) for a in self.args])
 
     # (a|b|...) & c == (a&c) | (b&c) | ...
     def expand(self):
@@ -348,7 +349,7 @@ class And(AndOr_Base):
             if isinstance(arg, Or):
                 arest = self.args[:i] + self.args[i + 1:]
 
-                orterms = [And( *(arest + (a,)) ) for a in arg.args]
+                orterms = [And(*(arest + (a,))) for a in arg.args]
                 for j in range(len(orterms)):
                     if isinstance(orterms[j], Logic):
                         orterms[j] = orterms[j].expand()
@@ -365,7 +366,7 @@ class Or(AndOr_Base):
 
     def _eval_propagate_not(self):
         # !(a|b|c ...) == !a & !b & !c ...
-        return And( *[Not(a) for a in self.args] )
+        return And(*[Not(a) for a in self.args])
 
 
 class Not(Logic):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -175,8 +175,10 @@ class Relational(Boolean, Expr, EvalfMixin):
 
         """
         ops = {Eq: Ne, Ge: Lt, Gt: Le, Le: Gt, Lt: Ge, Ne: Eq}
-        # If there ever will be new Relational subclasses, the following line will work until it is properly sorted out
-        # return ops.get(self.func, lambda a, b, evaluate=False: ~(self.func(a, b, evaluate=evaluate)))(*self.args, evaluate=False)
+        # If there ever will be new Relational subclasses, the following line
+        # will work until it is properly sorted out
+        # return ops.get(self.func, lambda a, b, evaluate=False: ~(self.func(a,
+        #      b, evaluate=evaluate)))(*self.args, evaluate=False)
         return Relational.__new__(ops.get(self.func), *self.args)
 
     def _eval_evalf(self, prec):
@@ -186,8 +188,8 @@ class Relational(Boolean, Expr, EvalfMixin):
     def canonical(self):
         """Return a canonical form of the relational by putting a
         Number on the rhs else ordering the args. The relation is also changed
-        so that the left-hand side expression does not start with a `-`. No other
-        simplification is attempted.
+        so that the left-hand side expression does not start with a `-`.
+        No other simplification is attempted.
 
         Examples
         ========
@@ -213,12 +215,15 @@ class Relational(Boolean, Expr, EvalfMixin):
             r = r.reversed
 
         # Check if first value has negative sign
-        if not isinstance(r.lhs, BooleanAtom) and r.lhs.could_extract_minus_sign():
+        if not isinstance(r.lhs, BooleanAtom) and \
+                r.lhs.could_extract_minus_sign():
             r = r.reversedsign
-        elif not isinstance(r.rhs, BooleanAtom) and not r.rhs.is_number and r.rhs.could_extract_minus_sign():
+        elif not isinstance(r.rhs, BooleanAtom) and not r.rhs.is_number and \
+                r.rhs.could_extract_minus_sign():
             # Right hand side has a minus, but not lhs.
             # How does the expression with reversed signs behave?
-            # This is so that expressions of the type Eq(x, -y) and Eq(-x, y) have the same canonical representation
+            # This is so that expressions of the type Eq(x, -y) and Eq(-x, y)
+            # have the same canonical representation
             expr1, _ = ordered([r.lhs, -r.rhs])
             if expr1 != r.lhs:
                 r = r.reversed.reversedsign
@@ -236,19 +241,20 @@ class Relational(Boolean, Expr, EvalfMixin):
             if a.func in (Eq, Ne) or b.func in (Eq, Ne):
                 if a.func != b.func:
                     return False
-                l, r = [i.equals(j, failing_expression=failing_expression)
-                    for i, j in zip(a.args, b.args)]
-                if l is True:
-                    return r
-                if r is True:
-                    return l
+                left, right = [i.equals(j,
+                                        failing_expression=failing_expression)
+                               for i, j in zip(a.args, b.args)]
+                if left is True:
+                    return right
+                if right is True:
+                    return left
                 lr, rl = [i.equals(j, failing_expression=failing_expression)
-                    for i, j in zip(a.args, b.reversed.args)]
+                          for i, j in zip(a.args, b.reversed.args)]
                 if lr is True:
                     return rl
                 if rl is True:
                     return lr
-                e = (l, r, lr, rl)
+                e = (left, right, lr, rl)
                 if all(i is False for i in e):
                     return False
                 for i in e:
@@ -259,20 +265,23 @@ class Relational(Boolean, Expr, EvalfMixin):
                     b = b.reversed
                 if a.func != b.func:
                     return False
-                l = a.lhs.equals(b.lhs, failing_expression=failing_expression)
-                if l is False:
+                left = a.lhs.equals(b.lhs,
+                                    failing_expression=failing_expression)
+                if left is False:
                     return False
-                r = a.rhs.equals(b.rhs, failing_expression=failing_expression)
-                if r is False:
+                right = a.rhs.equals(b.rhs,
+                                     failing_expression=failing_expression)
+                if right is False:
                     return False
-                if l is True:
-                    return r
-                return l
+                if left is True:
+                    return right
+                return left
 
     def _eval_simplify(self, ratio, measure, rational, inverse):
         r = self
-        r = r.func(*[i.simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
-            for i in r.args])
+        r = r.func(*[i.simplify(ratio=ratio, measure=measure,
+                                rational=rational, inverse=inverse)
+                     for i in r.args])
         if r.is_Relational:
             dif = r.lhs - r.rhs
             # replace dif with a valid Number that will
@@ -308,6 +317,7 @@ class Relational(Boolean, Expr, EvalfMixin):
     def binary_symbols(self):
         # override where necessary
         return set()
+
 
 Rel = Relational
 
@@ -438,15 +448,17 @@ class Equality(Relational):
                     elif n.is_zero is False:
                         rv = d.is_infinite
                         if rv is None:
-                            # if the condition that makes the denominator infinite does not
-                            # make the original expression True then False can be returned
+                            # if the condition that makes the denominator
+                            # infinite does not make the original expression
+                            # True then False can be returned
                             l, r = clear_coefficients(d, S.Infinity)
                             args = [_.subs(l, r) for _ in (lhs, rhs)]
                             if args != [lhs, rhs]:
                                 rv = fuzzy_bool(Eq(*args))
                                 if rv is True:
                                     rv = None
-                elif any(a.is_infinite for a in Add.make_args(n)):  # (inf or nan)/x != 0
+                elif any(a.is_infinite for a in Add.make_args(n)):
+                    # (inf or nan)/x != 0
                     rv = S.false
                 if rv is not None:
                     return _sympify(rv)
@@ -521,6 +533,7 @@ class Equality(Relational):
                 pass
         return e.canonical
 
+
 Eq = Equality
 
 
@@ -593,6 +606,7 @@ class Unequality(Relational):
             return self.func(*eq.args)
         return eq.negated  # result of Ne is the negated Eq
 
+
 Ne = Unequality
 
 
@@ -634,8 +648,8 @@ class _Inequality(Relational):
 class _Greater(_Inequality):
     """Not intended for general use
 
-    _Greater is only used so that GreaterThan and StrictGreaterThan may subclass
-    it for the .gts and .lts properties.
+    _Greater is only used so that GreaterThan and StrictGreaterThan may
+    subclass it for the .gts and .lts properties.
 
     """
     __slots__ = ()
@@ -743,8 +757,8 @@ class GreaterThan(_Greater):
     x < 2
 
     Another option is to use the Python inequality operators (>=, >, <=, <)
-    directly.  Their main advantage over the Ge, Gt, Le, and Lt counterparts, is
-    that one can write a more "mathematical looking" statement rather than
+    directly.  Their main advantage over the Ge, Gt, Le, and Lt counterparts,
+    is that one can write a more "mathematical looking" statement rather than
     littering the math with oddball function calls.  However there are certain
     (minor) caveats of which to be aware (search for 'gotcha', below).
 
@@ -901,6 +915,7 @@ class GreaterThan(_Greater):
         # We don't use the op symbol here: workaround issue #7951
         return _sympify(lhs.__ge__(rhs))
 
+
 Ge = GreaterThan
 
 
@@ -914,6 +929,7 @@ class LessThan(_Less):
     def _eval_relation(cls, lhs, rhs):
         # We don't use the op symbol here: workaround issue #7951
         return _sympify(lhs.__le__(rhs))
+
 
 Le = LessThan
 
@@ -929,6 +945,7 @@ class StrictGreaterThan(_Greater):
         # We don't use the op symbol here: workaround issue #7951
         return _sympify(lhs.__gt__(rhs))
 
+
 Gt = StrictGreaterThan
 
 
@@ -943,12 +960,13 @@ class StrictLessThan(_Less):
         # We don't use the op symbol here: workaround issue #7951
         return _sympify(lhs.__lt__(rhs))
 
+
 Lt = StrictLessThan
 
 
-# A class-specific (not object-specific) data item used for a minor speedup.  It
-# is defined here, rather than directly in the class, because the classes that
-# it references have not been defined until now (e.g. StrictLessThan).
+# A class-specific (not object-specific) data item used for a minor speedup.
+# It is defined here, rather than directly in the class, because the classes
+# that it references have not been defined until now (e.g. StrictLessThan).
 Relational.ValidRelationOperator = {
     None: Equality,
     '==': Equality,

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -3,6 +3,7 @@ from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sign, im, nan, Dummy, factorial, comp, refine
 )
 from sympy.core.compatibility import long, range
+from sympy.core.expr import unchanged
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import verify_numerically
@@ -345,8 +346,8 @@ def test_powerbug():
 def test_Mul_doesnt_expand_exp():
     x = Symbol('x')
     y = Symbol('y')
-    assert exp(x)*exp(y) == exp(x)*exp(y)
-    assert 2**x*2**y == 2**x*2**y
+    assert unchanged(Mul, exp(x), exp(y))
+    assert unchanged(Mul, 2**x, 2**y)
     assert x**2*x**3 == x**5
     assert 2**x*3**x == 6**x
     assert x**(y)*x**(2*y) == x**(3*y)

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -120,6 +120,15 @@ def test_subs():
     assert Symbol(u"text").subs({u"text": b1}) == b1
 
 
+def test_subs_with_unicode_symbols():
+    expr = Symbol('var1')
+    replaced = expr.subs('var1', u'x')
+    assert replaced.name == 'x'
+
+    replaced = expr.subs('var1', 'x')
+    assert replaced.name == 'x'
+
+
 def test_atoms():
     assert b21.atoms() == set()
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1127,7 +1127,7 @@ def test_issue_15241():
     assert (y*G + y*Gy*G).diff(y, G) == y*Gy.diff(y) + Gy + 1
 
 
-def test_issue_15266():
+def test_issue_15226():
     assert Subs(Derivative(f(y), x, y), y, g(x)).doit() != 0
 
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -301,11 +301,9 @@ def test_Subs():
         ).doit() == 2*exp(x)
     assert Subs(Derivative(g(x)**2, g(x), x), g(x), exp(x)
         ).doit(deep=False) == 2*Derivative(exp(x), x)
-
-    assert Derivative(f(x, g(x)), x).doit() == Derivative(g(x), x
-        )*Subs(Derivative(f(x, y), y), y, g(x)
-        ) + Subs(Derivative(f(y, g(x)), y), y, x)
-
+    assert Derivative(f(x, g(x)), x).doit() == Derivative(
+        f(x, g(x)), g(x))*Derivative(g(x), x) + Subs(Derivative(
+        f(y, g(x)), y), y, x)
 
 def test_doitdoit():
     done = Derivative(f(x, g(x)), x, g(x)).doit()

--- a/sympy/core/tests/test_logic.py
+++ b/sympy/core/tests/test_logic.py
@@ -1,5 +1,6 @@
+from sympy.core.compatibility import PY3
 from sympy.core.logic import (fuzzy_not, Logic, And, Or, Not, fuzzy_and,
-    fuzzy_or, _fuzzy_group, _torf)
+                              fuzzy_or, _fuzzy_group, _torf)
 from sympy.utilities.pytest import raises
 
 T = True
@@ -11,20 +12,19 @@ def test_torf():
     from sympy.utilities.iterables import cartes
     v = [T, F, U]
     for i in cartes(*[v]*3):
-        assert _torf(i) is (
-            True if all(j for j in i) else (False if all(j is False for j in i) else None))
+        assert _torf(i) is (True if all(j for j in i) else
+                            (False if all(j is False for j in i) else None))
 
 
 def test_fuzzy_group():
     from sympy.utilities.iterables import cartes
     v = [T, F, U]
     for i in cartes(*[v]*3):
-        assert _fuzzy_group(i) is (
-            None if None in i else (
-            True if all(j for j in i) else False))
-        assert _fuzzy_group(i, quick_exit=True) is (
-            None if (i.count(False) > 1) else (None if None in i else (
-            True if all(j for j in i) else False)))
+        assert _fuzzy_group(i) is (None if None in i else
+                                   (True if all(j for j in i) else False))
+        assert _fuzzy_group(i, quick_exit=True) is \
+            (None if (i.count(False) > 1) else
+             (None if None in i else (True if all(j for j in i) else False)))
     it = (True if (i == 0) else None for i in range(2))
     assert _torf(it) is None
     it = (True if (i == 1) else None for i in range(2))
@@ -75,6 +75,11 @@ def test_logic_cmp():
     assert And('a', 'b', 'c') == And('c', 'b', 'a')
     assert And('a', 'b', 'c') == And('c', 'a', 'b')
 
+    assert Not('a') < Not('b')
+    assert (Not('b') < Not('a')) is False
+    if PY3:
+        assert (Not('a') < 2) is False
+
 
 def test_logic_onearg():
     assert And() is True
@@ -115,11 +120,11 @@ def test_logic_combine_args():
     assert And('a', 'b', 'a') == And('a', 'b')
     assert Or('a', 'b', 'a') == Or('a', 'b')
 
-    assert And( And('a', 'b'), And('c', 'd') ) == And('a', 'b', 'c', 'd')
-    assert Or( Or('a', 'b'), Or('c', 'd') ) == Or('a', 'b', 'c', 'd')
+    assert And(And('a', 'b'), And('c', 'd')) == And('a', 'b', 'c', 'd')
+    assert Or(Or('a', 'b'), Or('c', 'd')) == Or('a', 'b', 'c', 'd')
 
-    assert Or( 't', And('n', 'p', 'r'), And('n', 'r'), And('n', 'p', 'r'), 't', And('n', 'r') ) == \
-        Or('t', And('n', 'p', 'r'), And('n', 'r'))
+    assert Or('t', And('n', 'p', 'r'), And('n', 'r'), And('n', 'p', 'r'), 't',
+              And('n', 'r')) == Or('t', And('n', 'p', 'r'), And('n', 'r'))
 
 
 def test_logic_expand():
@@ -155,16 +160,23 @@ def test_logic_fromstring():
     raises(ValueError, lambda: S('a|b'))
     raises(ValueError, lambda: S('!'))
     raises(ValueError, lambda: S('! a'))
+    raises(ValueError, lambda: S('!(a + 1)'))
+    raises(ValueError, lambda: S(''))
 
 
 def test_logic_not():
     assert Not('a') != '!a'
     assert Not('!a') != 'a'
+    assert Not(True) == False
+    assert Not(False) == True
 
     # NOTE: we may want to change default Not behaviour and put this
     # functionality into some method.
     assert Not(And('a', 'b')) == Or(Not('a'), Not('b'))
     assert Not(Or('a', 'b')) == And(Not('a'), Not('b'))
+
+    S = Logic.fromstring
+    raises(ValueError, lambda: Not(1))
 
 
 def test_formatting():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -277,7 +277,8 @@ def test_new_relational():
 
         raises(ValueError, lambda: Relational(x, 1, relation_type))
     assert all(Relational(x, 0, op).rel_op == '==' for op in ('eq', '=='))
-    assert all(Relational(x, 0, op).rel_op == '!=' for op in ('ne', '<>', '!='))
+    assert all(Relational(x, 0, op).rel_op == '!='
+               for op in ('ne', '<>', '!='))
     assert all(Relational(x, 0, op).rel_op == '>' for op in ('gt', '>'))
     assert all(Relational(x, 0, op).rel_op == '<' for op in ('lt', '<'))
     assert all(Relational(x, 0, op).rel_op == '>=' for op in ('ge', '>='))
@@ -600,7 +601,7 @@ def test_simplify_relational():
     # reason for the 'if r.is_Relational' in Relational's
     # _eval_simplify routine
     assert simplify(-(2**(3*pi/2) + 6**pi)**(1/pi) +
-        2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
+                    2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
     # canonical at least
     for f in (Eq, Ne):
         f(y, x).simplify() == f(x, y)
@@ -670,6 +671,7 @@ def test_issue_8444_nonworkingtests():
     assert x <= ceiling(x)
     assert (x > ceiling(x)) == False
 
+
 def test_issue_8444_workingtests():
     x = symbols('x')
     assert Gt(x, floor(x)) == Gt(x, floor(x), evaluate=False)
@@ -708,7 +710,6 @@ def test_issue_10401():
     assert Eq(fin/inf, 0) is T
     assert Eq(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
     assert Eq(inf, -inf) is F
-
 
     assert Eq(fin/(fin + 1), 1) is S.false
 
@@ -750,8 +751,7 @@ def test_issues_13081_12583_12534():
     # Rational(pi.n(p    )).n(25) = 3.14159265358979323846 1987
     assert [p for p in range(20, 50) if
             (Rational(pi.n(p)) < pi) and
-            (pi < Rational(pi.n(p + 1)))
-        ] == [20, 24, 27, 33, 37, 43, 48]
+            (pi < Rational(pi.n(p + 1)))] == [20, 24, 27, 33, 37, 43, 48]
     # pick one such precision and affirm that the reversed operation
     # gives the opposite result, i.e. if x < y is true then x > y
     # must be false
@@ -774,11 +774,9 @@ def test_issues_13081_12583_12534():
     # Float vs Rational
     # the rational form is less than the floating representation
     # at the same precision
-    assert [i for i in range(15, 50) if Rational(pi.n(i)) > pi.n(i)
-        ] == []
+    assert [i for i in range(15, 50) if Rational(pi.n(i)) > pi.n(i)] == []
     # this should be the same if we reverse the relational
-    assert [i for i in range(15, 50) if pi.n(i) < Rational(pi.n(i))
-        ] == []
+    assert [i for i in range(15, 50) if pi.n(i) < Rational(pi.n(i))] == []
 
 
 def test_binary_symbols():
@@ -850,6 +848,7 @@ def test_reversedsign_property():
     for f in (Eq, Ne, Ge, Gt, Le, Lt):
         assert f(-x, -y).reversedsign.reversedsign == f(-x, -y)
 
+
 def test_reversed_reversedsign_property():
     for f in (Eq, Ne, Ge, Gt, Le, Lt):
         assert f(x, y).reversed.reversedsign == f(x, y).reversedsign.reversed
@@ -861,14 +860,19 @@ def test_reversed_reversedsign_property():
         assert f(x, -y).reversed.reversedsign == f(x, -y).reversedsign.reversed
 
     for f in (Eq, Ne, Ge, Gt, Le, Lt):
-        assert f(-x, -y).reversed.reversedsign == f(-x, -y).reversedsign.reversed
+        assert f(-x, -y).reversed.reversedsign == \
+            f(-x, -y).reversedsign.reversed
+
 
 def test_improved_canonical():
     def test_different_forms(listofforms):
         for form1, form2 in combinations(listofforms, 2):
             assert form1.canonical == form2.canonical
+
     def generate_forms(expr):
-        return [expr, expr.reversed, expr.reversedsign, expr.reversed.reversedsign]
+        return [expr, expr.reversed, expr.reversedsign,
+                expr.reversed.reversedsign]
+
     test_different_forms(generate_forms(x > -y))
     test_different_forms(generate_forms(x >= -y))
     test_different_forms(generate_forms(Eq(x, -y)))

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -577,9 +577,10 @@ class Abs(Function):
         if self.args[0].is_real or self.args[0].is_imaginary:
             return Derivative(self.args[0], x, evaluate=True) \
                 * sign(conjugate(self.args[0]))
-        return (re(self.args[0]) * Derivative(re(self.args[0]), x,
+        rv = (re(self.args[0]) * Derivative(re(self.args[0]), x,
             evaluate=True) + im(self.args[0]) * Derivative(im(self.args[0]),
                 x, evaluate=True)) / Abs(self.args[0])
+        return rv.rewrite(sign)
 
     def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         # Note this only holds for real arg (since Heaviside is not defined

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -5,6 +5,7 @@ from sympy import (
     Interval, comp, Integral, Matrix, ImmutableMatrix, SparseMatrix,
     ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda, Derivative)
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.core.expr import unchanged
 
 
 def N_equals(a, b):
@@ -32,7 +33,7 @@ def test_re():
     assert re(E) == E
     assert re(-E) == -E
 
-    assert re(x) == re(x)
+    assert unchanged(re, x)
     assert re(x*I) == -im(x)
     assert re(r*I) == 0
     assert re(r) == r
@@ -128,7 +129,7 @@ def test_im():
     assert im(E*I) == E
     assert im(-E*I) == -E
 
-    assert im(x) == im(x)
+    assert unchanged(im, x)
     assert im(x*I) == re(x)
     assert im(r*I) == r
     assert im(r) == 0

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -3,7 +3,7 @@ from sympy import (
     Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,
     sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise,
     Interval, comp, Integral, Matrix, ImmutableMatrix, SparseMatrix,
-    ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda)
+    ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda, Derivative)
 from sympy.utilities.pytest import XFAIL, raises
 
 
@@ -907,3 +907,9 @@ def test_zero_assumptions():
 
     assert re(nzni).is_zero is False
     assert im(nzni).is_zero is None
+
+def test_issue_15893():
+    f = Function('f', real=True)
+    x = Symbol('x', real=True)
+    eq = Derivative(Abs(f(x)), f(x))
+    assert eq.doit() == sign(f(x))

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -51,7 +51,7 @@ def polytope_integrate(poly, expr=None, **kwargs):
     >>> from sympy.geometry.polygon import Polygon
     >>> from sympy.geometry.point import Point
     >>> from sympy.integrals.intpoly import polytope_integrate
-    >>> polygon = Polygon(Point(0,0), Point(0,1), Point(1,1), Point(1,0))
+    >>> polygon = Polygon(Point(0, 0), Point(0, 1), Point(1, 1), Point(1, 0))
     >>> polys = [1, x, y, x*y, x**2*y, x*y**2]
     >>> expr = x*y
     >>> polytope_integrate(polygon, expr)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1476,7 +1476,7 @@ def test_issue_15509():
         (-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, (a > -oo) & (a < oo) & Ne(a, 0)), \
             (-x_1*cos(b) + x_2*cos(b), True))
 
-
+@slow
 def test_issue_4311():
     x = symbols('x')
     assert integrate(x*abs(9-x**2), x) == Integral(x*abs(9-x**2), x)

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -2,8 +2,12 @@ from sympy import sqrt, Abs
 
 from sympy.core import S
 
-from sympy.integrals.intpoly import (decompose, best_origin,
-                                     polytope_integrate, point_sort)
+from sympy.integrals.intpoly import (decompose, best_origin, distance_to_side,
+                                     polytope_integrate, point_sort,
+                                     hyperplane_parameters, main_integrate3d,
+                                     main_integrate, polygon_integrate,
+                                     lineseg_integrate, integration_reduction,
+                                     integration_reduction_dynamic, is_vertex)
 
 from sympy.geometry.line import Segment2D
 from sympy.geometry.polygon import Polygon
@@ -514,3 +518,85 @@ def test_polytopes_intersecting_sides():
                    Point(4.203, 0.478))
     assert polytope_integrate(fig6, x**2 + x*y + y**2) ==\
         S(88161333955921)/(3*10**12)
+
+
+def test_max_degree():
+    polygon = Polygon((0, 0), (0, 1), (1, 1), (1, 0))
+    polys = [1, x, y, x*y, x**2*y, x*y**2]
+    assert polytope_integrate(polygon, polys, max_degree=3) == \
+        {1: 1, x: S(1)/2, y: S(1)/2, x*y: S(1)/4, x**2*y: S(1)/6, x*y**2: S(1)/6}
+
+
+def test_main_integrate3d():
+    cube = [[(0, 0, 0), (0, 0, 5), (0, 5, 0), (0, 5, 5), (5, 0, 0),\
+             (5, 0, 5), (5, 5, 0), (5, 5, 5)],\
+            [2, 6, 7, 3], [3, 7, 5, 1], [7, 6, 4, 5], [1, 5, 4, 0],\
+            [3, 1, 0, 2], [0, 4, 6, 2]]
+    vertices = cube[0]
+    faces = cube[1:]
+    hp_params = hyperplane_parameters(faces, vertices)
+    assert main_integrate3d(1, faces, vertices, hp_params) == -125
+    assert main_integrate3d(1, faces, vertices, hp_params, max_degree=1) == \
+        {1: -125, y: -S(625)/2, z: -S(625)/2, x: -S(625)/2}
+
+
+def test_main_integrate():
+    triangle = Polygon((0, 3), (5, 3), (1, 1))
+    facets = triangle.sides
+    hp_params = hyperplane_parameters(triangle)
+    assert main_integrate(x**2 + y**2, facets, hp_params) == S(325)/6
+    assert main_integrate(x**2 + y**2, facets, hp_params, max_degree=1) == \
+        {0: 0, 1: 5, y: S(35)/3, x: 10}
+
+
+def test_polygon_integrate():
+    cube = [[(0, 0, 0), (0, 0, 5), (0, 5, 0), (0, 5, 5), (5, 0, 0),\
+             (5, 0, 5), (5, 5, 0), (5, 5, 5)],\
+            [2, 6, 7, 3], [3, 7, 5, 1], [7, 6, 4, 5], [1, 5, 4, 0],\
+            [3, 1, 0, 2], [0, 4, 6, 2]]
+    facet = cube[1]
+    facets = cube[1:]
+    vertices = cube[0]
+    assert polygon_integrate(facet, [(0, 1, 0), 5], 0, facets, vertices, 1, 0) == -25
+
+
+def test_distance_to_side():
+    point = (0, 0, 0)
+    assert distance_to_side(point, [(0, 0, 1), (0, 1, 0)], (1, 0, 0)) == -sqrt(2)/2
+
+
+def test_lineseg_integrate():
+    polygon = [(0, 5, 0), (5, 5, 0), (5, 5, 5), (0, 5, 5)]
+    line_seg = [(0, 5, 0), (5, 5, 0)]
+    assert lineseg_integrate(polygon, 0, line_seg, 1, 0) == 5
+    assert lineseg_integrate(polygon, 0, line_seg, 0, 0) == 0
+
+
+def test_integration_reduction():
+    triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
+    facets = triangle.sides
+    a, b = hyperplane_parameters(triangle)[0]
+    assert integration_reduction(facets, 0, a, b, 1, (x, y), 0) == 5
+    assert integration_reduction(facets, 0, a, b, 0, (x, y), 0) == 0
+
+
+def test_integration_reduction_dynamic():
+    triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
+    facets = triangle.sides
+    a, b = hyperplane_parameters(triangle)[0]
+    x0 = facets[0].points[0]
+    monomial_values = [[0, 0, 0, 0], [1, 0, 0, 5],\
+                       [y, 0, 1, 15], [x, 1, 0, None]]
+
+    assert integration_reduction_dynamic(facets, 0, a, b, x, 1, (x, y), 1,\
+                                         0, 1, x0, monomial_values, 3) == S(25)/2
+    assert integration_reduction_dynamic(facets, 0, a, b, 0, 1, (x, y), 1,\
+                                         0, 1, x0, monomial_values, 3) == 0
+
+
+def test_is_vertex():
+    assert is_vertex(2) is False
+    assert is_vertex((2, 3)) is True
+    assert is_vertex(Point(2, 3)) is True
+    assert is_vertex((2, 3, 4)) is True
+    assert is_vertex((2, 3, 4, 5)) is False

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -113,7 +113,7 @@ class Boolean(Basic):
         if self.has(Relational) or other.has(Relational):
             raise NotImplementedError('handling of relationals')
         return self.atoms() == other.atoms() and \
-                not satisfiable(Not(Equivalent(self, other)))
+            not satisfiable(Not(Equivalent(self, other)))
 
     def to_nnf(self, simplify=True):
         # override where necessary
@@ -163,8 +163,8 @@ class Boolean(Basic):
     def binary_symbols(self):
         from sympy.core.relational import Eq, Ne
         return set().union(*[i.binary_symbols for i in self.args
-            if i.is_Boolean or i.is_Symbol
-            or isinstance(i, (Eq, Ne))])
+                           if i.is_Boolean or i.is_Symbol
+                           or isinstance(i, (Eq, Ne))])
 
 
 class BooleanAtom(Boolean):
@@ -255,10 +255,9 @@ class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):
     ``True`` or ``False``, and does so in terms of structural equality
     rather than mathematical, so it should return ``True``. The assumptions
     system should use ``True`` and ``False``. Aside from not satisfying
-    the above rule of thumb, the
-    assumptions system uses a three-valued logic (``True``, ``False``, ``None``),
-    whereas ``S.true`` and ``S.false`` represent a two-valued logic. When in
-    doubt, use ``True``.
+    the above rule of thumb, the assumptions system uses a three-valued logic
+    (``True``, ``False``, ``None``), whereas ``S.true`` and ``S.false``
+    represent a two-valued logic. When in doubt, use ``True``.
 
     "``S.true == True is True``."
 
@@ -403,6 +402,7 @@ class BooleanFalse(with_metaclass(Singleton, BooleanAtom)):
         """
         return S.EmptySet
 
+
 true = BooleanTrue()
 false = BooleanFalse()
 # We want S.true and S.false to work, rather than S.BooleanTrue and
@@ -414,6 +414,7 @@ S.false = false
 
 converter[bool] = lambda x: S.true if x else S.false
 
+
 class BooleanFunction(Application, Boolean):
     """Boolean function is a function that lives in a boolean space
     It is used as base class for And, Or, Not, etc.
@@ -422,10 +423,12 @@ class BooleanFunction(Application, Boolean):
 
     def _eval_simplify(self, ratio, measure, rational, inverse):
         rv = self.func(*[a._eval_simplify(ratio=ratio, measure=measure,
-            rational=rational, inverse=inverse) for a in self.args])
+                                          rational=rational, inverse=inverse)
+                         for a in self.args])
         return simplify_logic(rv)
 
-    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+    def simplify(self, ratio=1.7, measure=count_ops, rational=False,
+                 inverse=False):
         return self._eval_simplify(ratio, measure, rational, inverse)
 
     # /// drop when Py2 is no longer supported
@@ -505,7 +508,9 @@ class BooleanFunction(Application, Boolean):
         else:
             return S.Zero
 
-    def _apply_patternbased_simplification(self, rv, patterns, measure, dominatingvalue, replacementvalue=None):
+    def _apply_patternbased_simplification(self, rv, patterns, measure,
+                                           dominatingvalue,
+                                           replacementvalue=None):
         """
         Replace patterns of Relational
 
@@ -531,17 +536,21 @@ class BooleanFunction(Application, Boolean):
             evaluates to dominatingvalue.
             For example, for Nand S.false is dominating, but in this case
             the resulting value is S.true. Default is None. If replacementvalue
-            is None and dominatingvalue is not None, replacementvalue = dominatingvalue
+            is None and dominatingvalue is not None,
+            replacementvalue = dominatingvalue
         """
         from sympy.core.relational import Relational, _canonical
         if replacementvalue is None and dominatingvalue is not None:
             replacementvalue = dominatingvalue
         # Use replacement patterns for Relationals
         changed = True
-        Rel, nonRel = sift(rv.args, lambda i: isinstance(i, Relational), binary=True)
+        Rel, nonRel = sift(rv.args, lambda i: isinstance(i, Relational),
+                           binary=True)
         if len(Rel) <= 1:
             return rv
-        Rel, nonRealRel = sift(rv.args, lambda i: all(s.is_real is not False for s in i.free_symbols), binary=True)
+        Rel, nonRealRel = sift(rv.args, lambda i: all(s.is_real is not False
+                                                      for s in i.free_symbols),
+                               binary=True)
         Rel = [i.canonical for i in Rel]
         while changed and len(Rel) >= 2:
             changed = False
@@ -559,7 +568,8 @@ class BooleanFunction(Application, Boolean):
                     if tmpres:
                         res.append((tmpres, oldexpr))
                     # Try reversing first relational
-                    # This and the rest should not be required with a better canonical
+                    # This and the rest should not be required with a better
+                    # canonical
                     oldexpr = rv.func(pi.reversed, pj)
                     tmpres = oldexpr.match(pattern)
                     if tmpres:
@@ -584,13 +594,16 @@ class BooleanFunction(Application, Boolean):
                                 # will be replacementvalue
                                 return replacementvalue
                             # add replacement
-                            if not isinstance(np, ITE): # We only want to use ITE replacements if they simplify
-                                costsaving = measure(oldexpr) - measure(np) # ratio?
+                            if not isinstance(np, ITE):
+                                # We only want to use ITE replacements if
+                                # they simplify to a relational
+                                costsaving = measure(oldexpr) - measure(np)
                                 if costsaving > 0:
                                     results.append((costsaving, (i, j, np)))
             if results:
                 # Sort results based on complexity
-                results = list(reversed(sorted(results, key=lambda pair: pair[0])))
+                results = list(reversed(sorted(results,
+                                               key=lambda pair: pair[0])))
                 # Replace the one providing most simplification
                 cost, replacement = results[0]
                 i, j, newrel = replacement
@@ -604,8 +617,10 @@ class BooleanFunction(Application, Boolean):
                 # We did change something so try again
                 changed = True
 
-        rv = rv.func(*([_canonical(i) for i in ordered(Rel)] + nonRel + nonRealRel))
+        rv = rv.func(*([_canonical(i) for i in ordered(Rel)]
+                     + nonRel + nonRealRel))
         return rv
+
 
 class And(LatticeOp, BooleanFunction):
     """
@@ -667,7 +682,8 @@ class And(LatticeOp, BooleanFunction):
             return rv
         # simplify args that are equalities involving
         # symbols so x == 0 & x == y -> x==0 & y == 0
-        Rel, nonRel = sift(rv.args, lambda i: isinstance(i, Relational), binary=True)
+        Rel, nonRel = sift(rv.args, lambda i: isinstance(i, Relational),
+                           binary=True)
         if not Rel:
             return rv
         eqs, other = sift(Rel, lambda i: isinstance(i, Equality), binary=True)
@@ -713,7 +729,8 @@ class And(LatticeOp, BooleanFunction):
         other = [ei.subs(reps) for ei in other]
         rv = rv.func(*([i.canonical for i in (eqs + other)] + nonRel))
         patterns = simplify_patterns_and()
-        return self._apply_patternbased_simplification(rv, patterns, measure, False)
+        return self._apply_patternbased_simplification(rv, patterns,
+                                                       measure, False)
 
     def _eval_as_set(self):
         from sympy.sets.sets import Intersection
@@ -779,7 +796,8 @@ class Or(LatticeOp, BooleanFunction):
         if not isinstance(rv, Or):
             return rv
         patterns = simplify_patterns_or()
-        return self._apply_patternbased_simplification(rv, patterns, measure, S.true)
+        return self._apply_patternbased_simplification(rv, patterns,
+                                                       measure, S.true)
 
 
 class Not(BooleanFunction):
@@ -887,7 +905,8 @@ class Not(BooleanFunction):
             return And._to_nnf(a, ~b, simplify=simplify)
 
         if func == Equivalent:
-            return And._to_nnf(Or(*args), Or(*[~arg for arg in args]), simplify=simplify)
+            return And._to_nnf(Or(*args), Or(*[~arg for arg in args]),
+                               simplify=simplify)
 
         if func == Xor:
             result = []
@@ -960,7 +979,8 @@ class Xor(BooleanFunction):
                 argset.remove(arg)
             else:
                 argset.add(arg)
-        rel = [(r, r.canonical, r.negated.canonical) for r in argset if r.is_Relational]
+        rel = [(r, r.canonical, r.negated.canonical)
+               for r in argset if r.is_Relational]
         odd = False  # is number of complimentary pairs odd? start 0 -> False
         remove = []
         for i, (r, c, nc) in enumerate(rel):
@@ -1006,13 +1026,16 @@ class Xor(BooleanFunction):
 
     def _eval_simplify(self, ratio, measure, rational, inverse):
         # as standard simplify uses simplify_logic which writes things as
-        # And and Or, we only simplify the partial expressions before using patterns
+        # And and Or, we only simplify the partial expressions before using
+        # patterns
         rv = self.func(*[a._eval_simplify(ratio=ratio, measure=measure,
-            rational=rational, inverse=inverse) for a in self.args])
-        if not isinstance(rv, Xor): # This shouldn't really happen here
+                                          rational=rational, inverse=inverse)
+                       for a in self.args])
+        if not isinstance(rv, Xor):  # This shouldn't really happen here
             return rv
         patterns = simplify_patterns_xor()
-        return self._apply_patternbased_simplification(rv, patterns, measure, None)
+        return self._apply_patternbased_simplification(rv, patterns,
+                                                       measure, None)
 
 
 class Nand(BooleanFunction):
@@ -1215,7 +1238,7 @@ class Equivalent(BooleanFunction):
 
         argset = set(args)
         for x in args:
-            if isinstance(x, Number) or x in [True, False]: # Includes 0, 1
+            if isinstance(x, Number) or x in [True, False]:  # Includes 0, 1
                 argset.discard(x)
                 argset.add(True if x else False)
         rel = []
@@ -1374,7 +1397,7 @@ class ITE(BooleanFunction):
         from sympy.functions import Piecewise
         return Piecewise((args[1], args[0]), (args[2], True))
 
-### end class definitions. Some useful methods
+# end class definitions. Some useful methods
 
 
 def conjuncts(expr):
@@ -1458,10 +1481,12 @@ def _distribute(info):
             return info[0]
         rest = info[2](*[a for a in info[0].args if a is not conj])
         return info[1](*list(map(_distribute,
-            [(info[2](c, rest), info[1], info[2]) for c in conj.args])))
+                                 [(info[2](c, rest), info[1], info[2])
+                                  for c in conj.args])))
     elif isinstance(info[0], info[1]):
         return info[1](*list(map(_distribute,
-            [(x, info[1], info[2]) for x in info[0].args])))
+                                 [(x, info[1], info[2])
+                                  for x in info[0].args])))
     else:
         return info[0]
 
@@ -1972,46 +1997,57 @@ def _rem_redundancy(l1, terms):
 
     if len(terms):
         # Create dominating matrix
-        dominationmatrix = [[0]*len(l1) for n in range(len(terms))]
+        dommatrix = [[0]*len(l1) for n in range(len(terms))]
         for primei, prime in enumerate(l1):
             for termi, term in enumerate(terms):
                 if _compare_term(term, prime):
-                    dominationmatrix[termi][primei] = 1
+                    dommatrix[termi][primei] = 1
 
-        nondominatedprimeimplicants = list(range(len(l1)))
-        nondominatedterms = list(range(len(terms)))
+        # Non-dominated prime implicants, dominated set to None
+        ndprimeimplicants = list(range(len(l1)))
+        # Non-dominated terms, dominated set to None
+        ndterms = list(range(len(terms)))
 
         # Mark dominated rows and columns
-        oldnondominatedterms = None
-        oldnondominatedprimeimplicants = None
-        while nondominatedterms != oldnondominatedterms or nondominatedprimeimplicants != oldnondominatedprimeimplicants:
-            oldnondominatedterms = nondominatedterms[:]
-            oldnondominatedprimeimplicants = nondominatedprimeimplicants[:]
-            for rowi, row in enumerate(dominationmatrix):
-                if nondominatedterms[rowi] is not None:
-                    row = [row[i] for i in [_ for _ in nondominatedprimeimplicants if _ is not None]]
-                    for row2i, row2 in enumerate(dominationmatrix):
-                        if rowi != row2i and nondominatedterms[row2i] is not None:
-                            row2 = [row2[i] for i in [_ for _ in nondominatedprimeimplicants if _ is not None]]
+        oldndterms = None
+        oldndprimeimplicants = None
+        while ndterms != oldndterms or \
+                ndprimeimplicants != oldndprimeimplicants:
+            oldndterms = ndterms[:]
+            oldndprimeimplicants = ndprimeimplicants[:]
+            for rowi, row in enumerate(dommatrix):
+                if ndterms[rowi] is not None:
+                    row = [row[i] for i in
+                           [_ for _ in ndprimeimplicants if _ is not None]]
+                    for row2i, row2 in enumerate(dommatrix):
+                        if rowi != row2i and ndterms[row2i] is not None:
+                            row2 = [row2[i] for i in
+                                    [_ for _ in ndprimeimplicants
+                                     if _ is not None]]
                             if all(a >= b for (a, b) in zip(row2, row)):
                                 # row2 dominating row, keep row
-                                nondominatedterms[row2i] = None
+                                ndterms[row2i] = None
             for coli in range(len(l1)):
-                if nondominatedprimeimplicants[coli] is not None:
-                    col = [dominationmatrix[a][coli] for a in range(len(terms))]
-                    col = [col[i] for i in [_ for _ in oldnondominatedterms if _ is not None]]
+                if ndprimeimplicants[coli] is not None:
+                    col = [dommatrix[a][coli] for a in range(len(terms))]
+                    col = [col[i] for i in
+                           [_ for _ in oldndterms if _ is not None]]
                     for col2i in range(len(l1)):
-                        if coli != col2i and nondominatedprimeimplicants[col2i] is not None:
-                            col2 = [dominationmatrix[a][col2i] for a in range(len(terms))]
-                            col2 = [col2[i] for i in [_ for _ in oldnondominatedterms if _ is not None]]
+                        if coli != col2i and \
+                                ndprimeimplicants[col2i] is not None:
+                            col2 = [dommatrix[a][col2i]
+                                    for a in range(len(terms))]
+                            col2 = [col2[i] for i in
+                                    [_ for _ in oldndterms if _ is not None]]
                             if all(a >= b for (a, b) in zip(col, col2)):
                                 # col dominating col2, keep col
-                                nondominatedprimeimplicants[col2i] = None
-        l1 = [l1[i] for i in [_ for _ in nondominatedprimeimplicants if _ is not None]]
+                                ndprimeimplicants[col2i] = None
+        l1 = [l1[i] for i in [_ for _ in ndprimeimplicants if _ is not None]]
 
         return l1
     else:
         return []
+
 
 def _input_to_binlist(inputlist, variables):
     binlist = []
@@ -2029,11 +2065,15 @@ def _input_to_binlist(inputlist, variables):
                 binlist.append([d[v] for v in variables])
         elif isinstance(val, (list, tuple)):
             if len(val) != bits:
-                raise ValueError("Each term must contain {} bits as there are {} variables\n(or be an integer)".format(bits, bits))
+                raise ValueError("Each term must contain {} bits as there are"
+                                 "\n{} variables (or be an integer)."
+                                 "".format(bits, bits))
             binlist.append(list(val))
         else:
-            raise TypeError("A term list can only contain lists, ints or dicts.")
+            raise TypeError("A term list can only contain lists,"
+                            " ints or dicts.")
     return binlist
+
 
 def SOPform(variables, minterms, dontcares=None):
     """
@@ -2262,7 +2302,7 @@ def simplify_logic(expr, form=None, deep=True, force=False):
     variables = c + v
     truthtable = []
     # standardize constants to be 1 or 0 in keeping with truthtable
-    c = [1 if i==True else 0 for i in c]
+    c = [1 if i == True else 0 for i in c]
     for t in product([0, 1], repeat=len(v)):
         if expr.xreplace(dict(zip(v, t))) == True:
             truthtable.append(c + list(t))
@@ -2411,6 +2451,7 @@ def bool_map(bool1, bool2):
         return a, m
     return m
 
+
 def simplify_patterns_and():
     from sympy.functions.elementary.miscellaneous import Min, Max
     from sympy.core import Wild
@@ -2445,6 +2486,7 @@ def simplify_patterns_and():
                      )
     return _matchers_and
 
+
 def simplify_patterns_or():
     from sympy.functions.elementary.miscellaneous import Min, Max
     from sympy.core import Wild
@@ -2453,27 +2495,27 @@ def simplify_patterns_or():
     b = Wild('b')
     c = Wild('c')
     _matchers_or = ((Or(Eq(a, b), Ge(a, b)), Ge(a, b)),
-                     (Or(Eq(a, b), Gt(a, b)), Ge(a, b)),
-                     (Or(Eq(a, b), Le(a, b)), Le(a, b)),
-                     (Or(Eq(a, b), Lt(a, b)), Le(a, b)),
-                     (Or(Ge(a, b), Gt(a, b)), Ge(a, b)),
-                     (Or(Ge(a, b), Le(a, b)), S.true),
-                     (Or(Ge(a, b), Lt(a, b)), S.true),
-                     (Or(Ge(a, b), Ne(a, b)), S.true),
-                     (Or(Gt(a, b), Le(a, b)), S.true),
-                     (Or(Gt(a, b), Lt(a, b)), Ne(a, b)),
-                     (Or(Gt(a, b), Ne(a, b)), Ne(a, b)),
-                     (Or(Le(a, b), Lt(a, b)), Le(a, b)),
-                     (Or(Le(a, b), Ne(a, b)), S.true),
-                     (Or(Lt(a, b), Ne(a, b)), Ne(a, b)),
-                     # Min/max
-                     (Or(Ge(a, b), Ge(a, c)), Ge(a, Min(b, c))),
-                     (Or(Ge(a, b), Gt(a, c)), ITE(b > c, Gt(a, c), Ge(a, b))),
-                     (Or(Gt(a, b), Gt(a, c)), Gt(a, Min(b, c))),
-                     (Or(Le(a, b), Le(a, c)), Le(a, Max(b, c))),
-                     (Or(Le(a, b), Lt(a, c)), ITE(b >= c, Le(a, b), Lt(a, c))),
-                     (Or(Lt(a, b), Lt(a, c)), Lt(a, Max(b, c))),
-                     )
+                    (Or(Eq(a, b), Gt(a, b)), Ge(a, b)),
+                    (Or(Eq(a, b), Le(a, b)), Le(a, b)),
+                    (Or(Eq(a, b), Lt(a, b)), Le(a, b)),
+                    (Or(Ge(a, b), Gt(a, b)), Ge(a, b)),
+                    (Or(Ge(a, b), Le(a, b)), S.true),
+                    (Or(Ge(a, b), Lt(a, b)), S.true),
+                    (Or(Ge(a, b), Ne(a, b)), S.true),
+                    (Or(Gt(a, b), Le(a, b)), S.true),
+                    (Or(Gt(a, b), Lt(a, b)), Ne(a, b)),
+                    (Or(Gt(a, b), Ne(a, b)), Ne(a, b)),
+                    (Or(Le(a, b), Lt(a, b)), Le(a, b)),
+                    (Or(Le(a, b), Ne(a, b)), S.true),
+                    (Or(Lt(a, b), Ne(a, b)), Ne(a, b)),
+                    # Min/max
+                    (Or(Ge(a, b), Ge(a, c)), Ge(a, Min(b, c))),
+                    (Or(Ge(a, b), Gt(a, c)), ITE(b > c, Gt(a, c), Ge(a, b))),
+                    (Or(Gt(a, b), Gt(a, c)), Gt(a, Min(b, c))),
+                    (Or(Le(a, b), Le(a, c)), Le(a, Max(b, c))),
+                    (Or(Le(a, b), Lt(a, c)), ITE(b >= c, Le(a, b), Lt(a, c))),
+                    (Or(Lt(a, b), Lt(a, c)), Lt(a, Max(b, c))),
+                    )
     return _matchers_or
 
 def simplify_patterns_xor():
@@ -2498,11 +2540,19 @@ def simplify_patterns_xor():
                      (Xor(Le(a, b), Ne(a, b)), Ge(a, b)),
                      (Xor(Lt(a, b), Ne(a, b)), Gt(a, b)),
                      # Min/max
-                     (Xor(Ge(a, b), Ge(a, c)), And(Ge(a, Min(b, c)), Lt(a, Max(b, c)))),
-                     (Xor(Ge(a, b), Gt(a, c)), ITE(b > c, And(Gt(a, c), Lt(a, b)), And(Ge(a, b), Le(a, c)))),
-                     (Xor(Gt(a, b), Gt(a, c)), And(Gt(a, Min(b, c)), Le(a, Max(b, c)))),
-                     (Xor(Le(a, b), Le(a, c)), And(Le(a, Max(b, c)), Gt(a, Min(b, c)))),
-                     (Xor(Le(a, b), Lt(a, c)), ITE(b < c, And(Lt(a, c), Gt(a, b)), And(Le(a, b), Ge(a, c)))),
-                     (Xor(Lt(a, b), Lt(a, c)), And(Lt(a, Max(b, c)), Ge(a, Min(b, c)))),
+                     (Xor(Ge(a, b), Ge(a, c)),
+                      And(Ge(a, Min(b, c)), Lt(a, Max(b, c)))),
+                     (Xor(Ge(a, b), Gt(a, c)),
+                      ITE(b > c, And(Gt(a, c), Lt(a, b)),
+                          And(Ge(a, b), Le(a, c)))),
+                     (Xor(Gt(a, b), Gt(a, c)),
+                      And(Gt(a, Min(b, c)), Le(a, Max(b, c)))),
+                     (Xor(Le(a, b), Le(a, c)),
+                      And(Le(a, Max(b, c)), Gt(a, Min(b, c)))),
+                     (Xor(Le(a, b), Lt(a, c)),
+                      ITE(b < c, And(Lt(a, c), Gt(a, b)),
+                          And(Le(a, b), Ge(a, c)))),
+                     (Xor(Lt(a, b), Lt(a, c)),
+                      And(Lt(a, Max(b, c)), Ge(a, Min(b, c)))),
                      )
     return _matchers_xor

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,5 +1,4 @@
 from sympy.assumptions.ask import Q
-from sympy.core.containers import Tuple
 from sympy.core.numbers import oo
 from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.singleton import S
@@ -26,6 +25,7 @@ from itertools import combinations
 A, B, C, D = symbols('A:D')
 a, b, c, d, e, w, x, y, z = symbols('a:e w:z')
 
+
 def test_overloading():
     """Test that |, & are overloaded as expected"""
 
@@ -43,7 +43,7 @@ def test_And():
     assert And(A) == A
     assert And(True) is true
     assert And(False) is false
-    assert And(True, True ) is true
+    assert And(True, True) is true
     assert And(True, False) is false
     assert And(False, False) is false
     assert And(True, A) == A
@@ -66,7 +66,7 @@ def test_Or():
     assert Or(A) == A
     assert Or(True) is true
     assert Or(False) is false
-    assert Or(True, True ) is true
+    assert Or(True, True) is true
     assert Or(True, False) is true
     assert Or(False, False) is false
     assert Or(True, A) is true
@@ -93,7 +93,7 @@ def test_Xor():
     assert Xor(True, False, False, A, B) == ~Xor(A, B)
     assert Xor(True) is true
     assert Xor(False) is false
-    assert Xor(True, True ) is false
+    assert Xor(True, True) is false
     assert Xor(True, False) is true
     assert Xor(False, False) is false
     assert Xor(True, A) == ~A
@@ -123,7 +123,7 @@ def test_Nand():
     assert Nand(A) == ~A
     assert Nand(True) is false
     assert Nand(False) is true
-    assert Nand(True, True ) is false
+    assert Nand(True, True) is false
     assert Nand(True, False) is true
     assert Nand(False, False) is true
     assert Nand(True, A) == ~A
@@ -138,7 +138,7 @@ def test_Nor():
     assert Nor(A) == ~A
     assert Nor(True) is false
     assert Nor(False) is true
-    assert Nor(True, True ) is false
+    assert Nor(True, True) is false
     assert Nor(True, False) is false
     assert Nor(False, False) is true
     assert Nor(True, A) is false
@@ -146,6 +146,7 @@ def test_Nor():
     assert Nor(True, True, True) is false
     assert Nor(True, True, A) is false
     assert Nor(True, False, A) is false
+
 
 def test_Xnor():
     assert Xnor() is true
@@ -155,7 +156,7 @@ def test_Xnor():
     assert Xnor(A, A, A, A, A) == ~A
     assert Xnor(True) is false
     assert Xnor(False) is true
-    assert Xnor(True, True ) is true
+    assert Xnor(True, True) is true
     assert Xnor(True, False) is false
     assert Xnor(False, False) is true
     assert Xnor(True, A) == A
@@ -201,11 +202,12 @@ def test_Equivalent():
 
 
 def test_equals():
-    assert Not(Or(A, B)).equals( And(Not(A), Not(B)) ) is True
+    assert Not(Or(A, B)).equals(And(Not(A), Not(B))) is True
     assert Equivalent(A, B).equals((A >> B) & (B >> A)) is True
     assert ((A | ~B) & (~A | B)).equals((~A & ~B) | (A & B)) is True
     assert (A >> B).equals(~A >> ~B) is False
     assert (A >> (B >> A)).equals(A >> (C >> A)) is False
+    raises(NotImplementedError, lambda: (A & B).equals(A > B))
 
 
 def test_simplification():
@@ -215,13 +217,14 @@ def test_simplification():
     set1 = [[0, 0, 1], [0, 1, 1], [1, 0, 0], [1, 1, 0]]
     set2 = [[0, 0, 0], [0, 1, 0], [1, 0, 1], [1, 1, 1]]
     assert SOPform([x, y, z], set1) == Or(And(Not(x), z), And(Not(z), x))
-    assert Not(SOPform([x, y, z], set2)) == Not(Or(And(Not(x), Not(z)), And(x, z)))
+    assert Not(SOPform([x, y, z], set2)) == \
+        Not(Or(And(Not(x), Not(z)), And(x, z)))
     assert POSform([x, y, z], set1 + set2) is true
     assert SOPform([x, y, z], set1 + set2) is true
     assert SOPform([Dummy(), Dummy(), Dummy()], set1 + set2) is true
 
     minterms = [[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1],
-        [1, 1, 1, 1]]
+                [1, 1, 1, 1]]
     dontcares = [[0, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 1]]
     assert (
         SOPform([w, x, y, z], minterms, dontcares) ==
@@ -236,21 +239,29 @@ def test_simplification():
     assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
 
     minterms = [1, [0, 0, 1, 1], 7, [1, 0, 1, 1],
-        [1, 1, 1, 1]]
+                [1, 1, 1, 1]]
     dontcares = [0, [0, 0, 1, 0], 5]
     assert (
         SOPform([w, x, y, z], minterms, dontcares) ==
         Or(And(Not(w), z), And(y, z)))
     assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
 
-    minterms = [{y : 1, z: 1}, 1]
+    minterms = [1, {y: 1, z: 1}]
+    dontcares = [0, [0, 0, 1, 0], 5]
+    assert (
+        SOPform([w, x, y, z], minterms, dontcares) ==
+        Or(And(Not(w), z), And(y, z)))
+    assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
+
+
+    minterms = [{y: 1, z: 1}, 1]
     dontcares = [[0, 0, 0, 0]]
 
     minterms = [[0, 0, 0]]
-    raises(ValueError, lambda : SOPform([w, x, y, z], minterms))
-    raises(ValueError, lambda : POSform([w, x, y, z], minterms))
+    raises(ValueError, lambda: SOPform([w, x, y, z], minterms))
+    raises(ValueError, lambda: POSform([w, x, y, z], minterms))
 
-    raises(TypeError, lambda : POSform([w, x, y, z], ["abcdefg"]))
+    raises(TypeError, lambda: POSform([w, x, y, z], ["abcdefg"]))
 
     # test simplification
     ans = And(A, Or(B, C))
@@ -258,16 +269,25 @@ def test_simplification():
     assert simplify_logic((A & B) | (A & C)) == ans
     assert simplify_logic(Implies(A, B)) == Or(Not(A), B)
     assert simplify_logic(Equivalent(A, B)) == \
-           Or(And(A, B), And(Not(A), Not(B)))
+        Or(And(A, B), And(Not(A), Not(B)))
     assert simplify_logic(And(Equality(A, 2), C)) == And(Equality(A, 2), C)
     assert simplify_logic(And(Equality(A, 2), A)) is S.false
     assert simplify_logic(And(Equality(A, 2), A)) == And(Equality(A, 2), A)
     assert simplify_logic(And(Equality(A, B), C)) == And(Equality(A, B), C)
     assert simplify_logic(Or(And(Equality(A, 3), B), And(Equality(A, 3), C))) \
-           == And(Equality(A, 3), Or(B, C))
-    b = (~x & ~y & ~z) | ( ~x & ~y & z)
+        == And(Equality(A, 3), Or(B, C))
+    b = (~x & ~y & ~z) | (~x & ~y & z)
     e = And(A, b)
     assert simplify_logic(e) == A & ~x & ~y
+    raises(ValueError, lambda: simplify_logic(A & (B | C), form='blabla'))
+
+    # Check that expressions with nine variables or more are not simplified
+    # (without the force-flag)
+    a, b, c, d, e, f, g, h, j = symbols('a b c d e f g h j')
+    expr = a & b & c & d & e & f & g & h & j | \
+        a & b & c & d & e & f & g & h & ~j
+    # This expression can be simplified to get rid of the j variables
+    assert simplify_logic(expr) == expr
 
     # check input
     ans = SOPform([x, y], [[1, 0]])
@@ -307,19 +327,20 @@ def test_bool_map():
     """
 
     minterms = [[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1],
-        [1, 1, 1, 1]]
+                [1, 1, 1, 1]]
     assert bool_map(Not(Not(a)), a) == (a, {a: a})
     assert bool_map(SOPform([w, x, y, z], minterms),
-        POSform([w, x, y, z], minterms)) == \
+                    POSform([w, x, y, z], minterms)) == \
         (And(Or(Not(w), y), Or(Not(x), y), z), {x: x, w: w, z: z, y: y})
-    assert bool_map(SOPform([x, z, y],[[1, 0, 1]]),
-        SOPform([a, b, c],[[1, 0, 1]])) != False
-    function1 = SOPform([x,z,y],[[1, 0, 1], [0, 0, 1]])
-    function2 = SOPform([a,b,c],[[1, 0, 1], [1, 0, 0]])
+    assert bool_map(SOPform([x, z, y], [[1, 0, 1]]),
+                    SOPform([a, b, c], [[1, 0, 1]])) != False
+    function1 = SOPform([x, z, y], [[1, 0, 1], [0, 0, 1]])
+    function2 = SOPform([a, b, c], [[1, 0, 1], [1, 0, 0]])
     assert bool_map(function1, function2) == \
         (function1, {y: a, z: b})
     assert bool_map(Xor(x, y), ~Xor(x, y)) == False
-
+    assert bool_map(And(x, y), Or(x, y)) is None
+    assert bool_map(And(x, y), And(x, y, z)) is None
 
 def test_bool_symbol():
     """Test that mixing symbols with boolean values
@@ -352,6 +373,7 @@ def test_subs():
     assert (A | B).subs(B, True) is true
     assert (A | B).subs(B, False) == A
     assert (A | B).subs({A: True, B: True}) is true
+
 
 """
 we test for axioms of boolean algebra
@@ -422,18 +444,18 @@ def test_to_nnf():
     assert to_nnf(A >> B) == ~A | B
     assert to_nnf(Equivalent(A, B, C)) == (~A | B) & (~B | C) & (~C | A)
     assert to_nnf(A ^ B ^ C) == \
-            (A | B | C) & (~A | ~B | C) & (A | ~B | ~C) & (~A | B | ~C)
+        (A | B | C) & (~A | ~B | C) & (A | ~B | ~C) & (~A | B | ~C)
     assert to_nnf(ITE(A, B, C)) == (~A | B) & (A | C)
     assert to_nnf(Not(A | B | C)) == ~A & ~B & ~C
     assert to_nnf(Not(A & B & C)) == ~A | ~B | ~C
     assert to_nnf(Not(A >> B)) == A & ~B
     assert to_nnf(Not(Equivalent(A, B, C))) == And(Or(A, B, C), Or(~A, ~B, ~C))
     assert to_nnf(Not(A ^ B ^ C)) == \
-            (~A | B | C) & (A | ~B | C) & (A | B | ~C) & (~A | ~B | ~C)
+        (~A | B | C) & (A | ~B | C) & (A | B | ~C) & (~A | ~B | ~C)
     assert to_nnf(Not(ITE(A, B, C))) == (~A | ~B) & (A | ~C)
     assert to_nnf((A >> B) ^ (B >> A)) == (A & ~B) | (~A & B)
     assert to_nnf((A >> B) ^ (B >> A), False) == \
-            (~A | ~B | A | B) & ((A & ~B) | (~A & B))
+        (~A | ~B | A | B) & ((A & ~B) | (~A & B))
     assert ITE(A, 1, 0).to_nnf() == A
     assert ITE(A, 0, 1).to_nnf() == ~A
     # although ITE can hold non-Boolean, it will complain if
@@ -447,12 +469,14 @@ def test_to_cnf():
     assert to_cnf(A >> B) == (~A) | B
     assert to_cnf(A >> (B & C)) == (~A | B) & (~A | C)
     assert to_cnf(A & (B | C) | ~A & (B | C), True) == B | C
+    assert to_cnf(A & B) == And(A, B)
 
     assert to_cnf(Equivalent(A, B)) == And(Or(A, Not(B)), Or(B, Not(A)))
     assert to_cnf(Equivalent(A, B & C)) == \
-           (~A | B) & (~A | C) & (~B | ~C | A)
+        (~A | B) & (~A | C) & (~B | ~C | A)
     assert to_cnf(Equivalent(A, B | C), True) == \
         And(Or(Not(B), A), Or(Not(C), A), Or(B, C, Not(A)))
+    assert to_cnf(A + 1) == A + 1
 
 
 def test_to_dnf():
@@ -460,11 +484,13 @@ def test_to_dnf():
     assert to_dnf(A & (B | C)) == Or(And(A, B), And(A, C))
     assert to_dnf(A >> B) == (~A) | B
     assert to_dnf(A >> (B & C)) == (~A) | (B & C)
+    assert to_dnf(A | B) == A | B
 
     assert to_dnf(Equivalent(A, B), True) == \
-           Or(And(A, B), And(Not(A), Not(B)))
+        Or(And(A, B), And(Not(A), Not(B)))
     assert to_dnf(Equivalent(A, B & C), True) == \
-           Or(And(A, B, C), And(Not(A), Not(B)), And(Not(A), Not(C)))
+        Or(And(A, B, C), And(Not(A), Not(B)), And(Not(A), Not(C)))
+    assert to_dnf(A + 1) == A + 1
 
 
 def test_to_int_repr():
@@ -500,6 +526,7 @@ def test_is_cnf():
     assert is_cnf(x & y & z) is True
     assert is_cnf((x | y) & z) is True
     assert is_cnf((x & y) | z) is False
+    assert is_cnf(~(x & y) | z) is False
 
 
 def test_is_dnf():
@@ -508,6 +535,7 @@ def test_is_dnf():
     assert is_dnf(x & y & z) is True
     assert is_dnf((x & y) | z) is True
     assert is_dnf((x | y) & z) is False
+    assert is_dnf(~(x | y) & z) is False
 
 
 def test_ITE():
@@ -541,6 +569,10 @@ def test_ITE():
     assert ITE(Eq(x, False), y, x) == ITE(~x, y, x)
     assert ITE(Ne(x, True), y, x) == ITE(~x, y, x)
     assert ITE(Ne(x, False), y, x) == ITE(x, y, x)
+    assert ITE(Eq(S. true, x), y, x) == ITE(x, y, x)
+    assert ITE(Eq(S.false, x), y, x) == ITE(~x, y, x)
+    assert ITE(Ne(S.true, x), y, x) == ITE(~x, y, x)
+    assert ITE(Ne(S.false, x), y, x) == ITE(x, y, x)
     # 0 and 1 in the context are not treated as True/False
     # so the equality must always be False since dissimilar
     # objects cannot be equal
@@ -550,6 +582,7 @@ def test_ITE():
     assert ITE(Ne(x, 1), y, x) == y
     assert ITE(Eq(x, 0), y, z).subs(x, 0) == y
     assert ITE(Eq(x, 0), y, z).subs(x, 1) == z
+    raises(ValueError, lambda: ITE(x > 1, y, x, z))
 
 
 def test_is_literal():
@@ -629,9 +662,9 @@ def test_true_false():
         if not (T is True and F is False):
             assert T & F is false
             assert F & T is false
-        if not F is False:
+        if F is not False:
             assert F & F is false
-        if not T is True:
+        if T is not True:
             assert T & T is true
 
         assert Or(T, F) is true
@@ -643,9 +676,9 @@ def test_true_false():
         if not (T is True and F is False):
             assert T | F is true
             assert F | T is true
-        if not F is False:
+        if F is not False:
             assert F | F is false
-        if not T is True:
+        if T is not True:
             assert T | T is true
 
         assert Xor(T, F) is true
@@ -657,9 +690,9 @@ def test_true_false():
         if not (T is True and F is False):
             assert T ^ F is true
             assert F ^ T is true
-        if not F is False:
+        if F is not False:
             assert F ^ F is false
-        if not T is True:
+        if T is not True:
             assert T ^ T is false
 
         assert Nand(T, F) is true
@@ -689,10 +722,10 @@ def test_true_false():
             assert F << T is false
             assert F >> T is true
             assert T << F is true
-        if not F is False:
+        if F is not False:
             assert F >> F is true
             assert F << F is true
-        if not T is True:
+        if T is not True:
             assert T >> T is true
             assert T << T is true
 
@@ -724,12 +757,11 @@ def test_bool_as_set():
     assert Not(x > 2).as_set() == Interval(-oo, 2)
     # issue 10240
     assert Not(And(x > 2, x < 3)).as_set() == \
-        Union(Interval(-oo,2),Interval(3,oo))
+        Union(Interval(-oo, 2), Interval(3, oo))
     assert true.as_set() == S.UniversalSet
     assert false.as_set() == EmptySet()
     assert x.as_set() == S.UniversalSet
-    assert And(Or(x < 1, x > 3), x < 2
-        ).as_set() == Interval.open(-oo, 1)
+    assert And(Or(x < 1, x > 3), x < 2).as_set() == Interval.open(-oo, 1)
     assert And(x < 1, sin(x) < 3).as_set() == (x < 1).as_set()
     raises(NotImplementedError, lambda: (sin(x) < 1).as_set())
 
@@ -745,7 +777,7 @@ def test_multivariate_bool_as_set():
 
 def test_all_or_nothing():
     x = symbols('x', real=True)
-    args = x >=- oo, x <= oo
+    args = x >= -oo, x <= oo
     v = And(*args)
     if v.func is And:
         assert len(v.args) == len(args) - args.count(S.true)
@@ -788,13 +820,19 @@ def test_term_to_integer():
 def test_integer_to_term():
     assert integer_to_term(777) == [1, 1, 0, 0, 0, 0, 1, 0, 0, 1]
     assert integer_to_term(123, 3) == [1, 1, 1, 1, 0, 1, 1]
-    assert integer_to_term(456, 16) == [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0]
+    assert integer_to_term(456, 16) == [0, 0, 0, 0, 0, 0, 0, 1,
+                                        1, 1, 0, 0, 1, 0, 0, 0]
 
 
 def test_truth_table():
-    assert list(truth_table(And(x, y), [x, y], input=False)) == [False, False, False, True]
-    assert list(truth_table(x | y, [x, y], input=False)) == [False, True, True, True]
-    assert list(truth_table(x >> y, [x, y], input=False)) == [True, True, False, True]
+    assert list(truth_table(And(x, y), [x, y], input=False)) == \
+        [False, False, False, True]
+    assert list(truth_table(x | y, [x, y], input=False)) == \
+        [False, True, True, True]
+    assert list(truth_table(x >> y, [x, y], input=False)) == \
+        [True, True, False, True]
+    assert list(truth_table(And(x, y), [x, y])) == \
+        [([0, 0], False), ([0, 1], False), ([1, 0], False), ([1, 1], True)]
 
 
 def test_issue_8571():
@@ -864,15 +902,15 @@ def test_BooleanFunction_diff():
 def test_issue_14700():
     A, B, C, D, E, F, G, H = symbols('A B C D E F G H')
     q = ((B & D & H & ~F) | (B & H & ~C & ~D) | (B & H & ~C & ~F) |
-            (B & H & ~D & ~G) | (B & H & ~F & ~G) | (C & G & ~B & ~D) |
-            (C & G & ~D & ~H) | (C & G & ~F & ~H) | (D & F & H & ~B) |
-            (D & F & ~G & ~H) | (B & D & F & ~C & ~H) | (D & E & F & ~B & ~C) |
-            (D & F & ~A & ~B & ~C) | (D & F & ~A & ~C & ~H) |
-            (A & B & D & F & ~E & ~H))
+         (B & H & ~D & ~G) | (B & H & ~F & ~G) | (C & G & ~B & ~D) |
+         (C & G & ~D & ~H) | (C & G & ~F & ~H) | (D & F & H & ~B) |
+         (D & F & ~G & ~H) | (B & D & F & ~C & ~H) | (D & E & F & ~B & ~C) |
+         (D & F & ~A & ~B & ~C) | (D & F & ~A & ~C & ~H) |
+         (A & B & D & F & ~E & ~H))
     soldnf = ((B & D & H & ~F) | (D & F & H & ~B) | (B & H & ~C & ~D) |
-            (B & H & ~D & ~G) | (C & G & ~B & ~D) | (C & G & ~D & ~H) |
-            (C & G & ~F & ~H) | (D & F & ~G & ~H) | (D & E & F & ~C & ~H) |
-            (D & F & ~A & ~C & ~H) | (A & B & D & F & ~E & ~H))
+              (B & H & ~D & ~G) | (C & G & ~B & ~D) | (C & G & ~D & ~H) |
+              (C & G & ~F & ~H) | (D & F & ~G & ~H) | (D & E & F & ~C & ~H) |
+              (D & F & ~A & ~C & ~H) | (A & B & D & F & ~E & ~H))
     solcnf = ((B | C | D) & (B | D | G) & (C | D | H) & (C | F | H) &
               (D | G | H) & (F | G | H) & (B | F | ~D | ~H) &
               (~B | ~D | ~F | ~H) & (D | ~B | ~C | ~G | ~H) &
@@ -881,69 +919,122 @@ def test_issue_14700():
     assert simplify_logic(q, "dnf") == soldnf
     assert simplify_logic(q, "cnf") == solcnf
 
-    minterms = [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 1, 0], [0, 1, 1, 1], [0, 0, 1, 1], [1, 0, 1, 1]]
+    minterms = [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 1, 0], [0, 1, 1, 1],
+                [0, 0, 1, 1], [1, 0, 1, 1]]
     dontcares = [[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0], [1, 1, 0, 1]]
     assert SOPform([w, x, y, z], minterms) == (x & ~w) | (y & z & ~x)
     # Should not be more complicated with don't cares
-    assert SOPform([w, x, y, z], minterms, dontcares) == (x & ~w) | (y & z & ~x)
+    assert SOPform([w, x, y, z], minterms, dontcares) == \
+        (x & ~w) | (y & z & ~x)
 
 
 def test_relational_simplification():
     w, x, y, z = symbols('w x y z', real=True)
     d, e = symbols('d e', real=False)
+    # Test all combinations or sign and order
     assert Or(x >= y, x < y).simplify() == S.true
+    assert Or(x >= y, y > x).simplify() == S.true
+    assert Or(x >= y, -x > -y).simplify() == S.true
+    assert Or(x >= y, -y < -x).simplify() == S.true
+    assert Or(-x <= -y, x < y).simplify() == S.true
+    assert Or(-x <= -y, -x > -y).simplify() == S.true
+    assert Or(-x <= -y, y > x).simplify() == S.true
+    assert Or(-x <= -y, -y < -x).simplify() == S.true
+    assert Or(y <= x, x < y).simplify() == S.true
+    assert Or(y <= x, y > x).simplify() == S.true
+    assert Or(y <= x, -x > -y).simplify() == S.true
+    assert Or(y <= x, -y < -x).simplify() == S.true
+    assert Or(-y >= -x, x < y).simplify() == S.true
+    assert Or(-y >= -x, y > x).simplify() == S.true
+    assert Or(-y >= -x, -x > -y).simplify() == S.true
+    assert Or(-y >= -x, -y < -x).simplify() == S.true
+
     assert Or(x < y, x >= y).simplify() == S.true
+    assert Or(y > x, x >= y).simplify() == S.true
+    assert Or(-x > -y, x >= y).simplify() == S.true
+    assert Or(-y < -x, x >= y).simplify() == S.true
+    assert Or(x < y, -x <= -y).simplify() == S.true
+    assert Or(-x > -y, -x <= -y).simplify() == S.true
+    assert Or(y > x, -x <= -y).simplify() == S.true
+    assert Or(-y < -x, -x <= -y).simplify() == S.true
+    assert Or(x < y, y <= x).simplify() == S.true
+    assert Or(y > x, y <= x).simplify() == S.true
+    assert Or(-x > -y, y <= x).simplify() == S.true
+    assert Or(-y < -x, y <= x).simplify() == S.true
+    assert Or(x < y, -y >= -x).simplify() == S.true
+    assert Or(y > x, -y >= -x).simplify() == S.true
+    assert Or(-x > -y, -y >= -x).simplify() == S.true
+    assert Or(-y < -x, -y >= -x).simplify() == S.true
+
+    # Some other tests
+    assert Or(x >= y, w < z, x <= y).simplify() == S.true
     assert And(x >= y, x < y).simplify() == S.false
     assert Or(x >= y, Eq(y, x)).simplify() == (x >= y)
     assert And(x >= y, Eq(y, x)).simplify() == Eq(x, y)
-    assert Or(Eq(x,y), x >= y, w < y, z < y).simplify() == Or(x >= y, y > Min(w, z))
-    assert And(Eq(x,y), x >= y, w < y, y >= z, z < y).simplify() == And(Eq(x, y), y > Max(w, z))
-    assert Or(Eq(x,y), x >= 1, 2 < y, y >= 5, z < y).simplify() == (Eq(x, y) | (x >= 1) | (y > Min(2, z)))
-    assert And(Eq(x,y), x >= 1, 2 < y, y >= 5, z < y).simplify() == (Eq(x, y) & (x >= 1) & (y >= 5) & (y > z))
-    assert (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)).simplify() == (Eq(x, y) & Eq(d, e) & (d >= e))
+    assert Or(Eq(x, y), x >= y, w < y, z < y).simplify() == \
+        Or(x >= y, y > Min(w, z))
+    assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify() == \
+        And(Eq(x, y), y > Max(w, z))
+    assert Or(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify() == \
+        (Eq(x, y) | (x >= 1) | (y > Min(2, z)))
+    assert And(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify() == \
+        (Eq(x, y) & (x >= 1) & (y >= 5) & (y > z))
+    assert (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)).simplify() == \
+        (Eq(x, y) & Eq(d, e) & (d >= e))
     assert And(Eq(x, y), Eq(x, -y)).simplify() == And(Eq(x, 0), Eq(y, 0))
     assert Xor(x >= y, x <= y).simplify() == Ne(x, y)
+
 
 @slow
 def test_relational_simplification_numerically():
     def test_simplification_numerically_function(original, simplified):
         symb = original.free_symbols
         n = len(symb)
-        valuelist = list(set(list(combinations(list(range(-(n-1),n))*n, n))))
+        valuelist = list(set(list(combinations(list(range(-(n-1), n))*n, n))))
         for values in valuelist:
             sublist = dict(zip(symb, values))
             originalvalue = original.subs(sublist)
             simplifiedvalue = simplified.subs(sublist)
-            assert originalvalue == simplifiedvalue, "Original: {}\nand simplified: {}\ndo not evaluate to the same value for {}".format(original, simplified, sublist)
+            assert originalvalue == simplifiedvalue, "Original: {}\nand"\
+                " simplified: {}\ndo not evaluate to the same value for {}"\
+                "".format(original, simplified, sublist)
 
     w, x, y, z = symbols('w x y z', real=True)
     d, e = symbols('d e', real=False)
 
-    expressions = (And(Eq(x,y), x >= y, w < y, y >= z, z < y),
-                   And(Eq(x,y), x >= 1, 2 < y, y >= 5, z < y),
-                   Or(Eq(x,y), x >= 1, 2 < y, y >= 5, z < y),
+    expressions = (And(Eq(x, y), x >= y, w < y, y >= z, z < y),
+                   And(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y),
+                   Or(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y),
                    And(x >= y, Eq(y, x)),
-                   Or(And(Eq(x,y), x >= y, w < y, Or(y >= z, z < y)), And(Eq(x,y), x >= 1, 2 < y, y >= -1, z < y)),
-                   (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)),  )
+                   Or(And(Eq(x, y), x >= y, w < y, Or(y >= z, z < y)),
+                      And(Eq(x, y), x >= 1, 2 < y, y >= -1, z < y)),
+                   (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)),
+                   )
 
     for expression in expressions:
-        test_simplification_numerically_function(expression, expression.simplify())
+        test_simplification_numerically_function(expression,
+                                                 expression.simplify())
+
 
 def test_relational_simplification_patterns_numerically():
     from sympy.core import Wild
-    from sympy.logic.boolalg import simplify_patterns_and, simplify_patterns_or, simplify_patterns_xor
+    from sympy.logic.boolalg import simplify_patterns_and, \
+        simplify_patterns_or, simplify_patterns_xor
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
     symb = [a, b, c]
-    patternlists = [simplify_patterns_and(), simplify_patterns_or(), simplify_patterns_xor()]
+    patternlists = [simplify_patterns_and(), simplify_patterns_or(),
+                    simplify_patterns_xor()]
     for patternlist in patternlists:
         for pattern in patternlist:
             original = pattern[0]
             simplified = pattern[1]
-            valuelist = list(set(list(combinations(list(range(-2,2))*3, 3))))
+            valuelist = list(set(list(combinations(list(range(-2, 2))*3, 3))))
             for values in valuelist:
                 sublist = dict(zip(symb, values))
                 originalvalue = original.subs(sublist)
                 simplifiedvalue = simplified.subs(sublist)
-                assert originalvalue == simplifiedvalue, "Original: {}\nand simplified: {}\ndo not evaluate to the same value for {}".format(original, simplified, sublist)
+                assert originalvalue == simplifiedvalue, "Original: {}\nand"\
+                    " simplified: {}\ndo not evaluate to the same value for"\
+                    "{}".format(original, simplified, sublist)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,11 +1,10 @@
 from __future__ import print_function, division
 
 from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
-from .transpose import Transpose
-from sympy.core.sympify import _sympify
+from sympy.core import S
 from sympy.core.compatibility import range
+from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
-from sympy.core import S, Basic
 
 
 class MatPow(MatrixExpr):
@@ -90,6 +89,7 @@ class MatPow(MatrixExpr):
 
     def _eval_derivative_matrix_lines(self, x):
         from .matmul import MatMul
+        from .inverse import Inverse
         exp = self.exp
         if (exp > 0) == True:
             newexpr = MatMul.fromiter([self.base for i in range(exp)])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1727,13 +1727,21 @@ class MatrixEigen(MatrixSubspaces):
         condition_number
         """
         mat = self
-        # Compute eigenvalues of A.H A
-        valmultpairs = (mat.H * mat).eigenvals()
+        if self.rows >= self.cols:
+            valmultpairs = (mat.H * mat).eigenvals()
+        else:
+            valmultpairs = (mat * mat.H).eigenvals()
 
         # Expands result from eigenvals into a simple list
         vals = []
         for k, v in valmultpairs.items():
             vals += [sqrt(k)] * v  # dangerous! same k in several spots!
+
+        # Pad with zeros if singular values are computed in reverse way,
+        # to give consistent format.
+        if len(vals) < self.cols:
+            vals += [S.Zero] * (self.cols - len(vals))
+
         # sort them in descending order
         vals.sort(reverse=True, key=default_sort_key)
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -16,8 +16,10 @@ from sympy.matrices import (
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix)
 from sympy.core.compatibility import long, iterable, range
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten, capture
-from sympy.utilities.pytest import raises, XFAIL, slow, skip
+from sympy.utilities.pytest import (raises, XFAIL, slow, skip,
+    warns_deprecated_sympy)
 from sympy.solvers import solve
 from sympy.assumptions import Q
 
@@ -1148,12 +1150,14 @@ def test_diag():
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \
             == SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) \
-            == SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2) \
-            == SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) \
-            == SpecialOnlyMatrix.jordan_block(3, 2, band='upper') == Matrix([
-                    [2, 1, 0],
-                    [0, 2, 1],
-                    [0, 0, 2]])
+            == SpecialOnlyMatrix.jordan_block(3, 2, band='upper') \
+            == SpecialOnlyMatrix.jordan_block(
+                size=3, eigenval=2, eigenvalue=2) \
+            == Matrix([
+                [2, 1, 0],
+                [0, 2, 1],
+                [0, 0, 2]])
+
     assert SpecialOnlyMatrix.jordan_block(3, 2, band='lower') == Matrix([
                     [2, 0, 0],
                     [1, 2, 0],
@@ -1162,6 +1166,37 @@ def test_jordan_block():
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(2))
     # non-integral size
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(3.5, 2))
+    # size not specified
+    raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(eigenvalue=2))
+    # inconsistent eigenvalue
+    raises(ValueError,
+    lambda: SpecialOnlyMatrix.jordan_block(
+        eigenvalue=2, eigenval=4))
+
+    # Deprecated feature
+    raises(SymPyDeprecationWarning,
+    lambda: SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2))
+
+    raises(SymPyDeprecationWarning,
+    lambda: SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2))
+
+    with warns_deprecated_sympy():
+        assert SpecialOnlyMatrix.jordan_block(3, 2) == \
+            SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) == \
+            SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2)
+
+    with warns_deprecated_sympy():
+        assert SpecialOnlyMatrix.jordan_block(
+            rows=4, cols=3, eigenvalue=2) == \
+            Matrix([
+                [2, 1, 0],
+                [0, 2, 1],
+                [0, 0, 2],
+                [0, 0, 0]])
+
+    # Using alias keyword
+    assert SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) == \
+        SpecialOnlyMatrix.jordan_block(size=3, eigenval=2)
 
 
 # SubspaceOnlyMatrix tests

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1364,6 +1364,17 @@ def test_singular_values():
     vals = [sv.trigsimp() for sv in A.singular_values()]
     assert vals == [S(1), S(1)]
 
+    A = EigenOnlyMatrix([
+        [2, 4],
+        [1, 3],
+        [0, 0],
+        [0, 0]
+        ])
+    assert A.singular_values() == \
+        [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221))]
+    assert A.T.singular_values() == \
+        [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0]
+
 
 # CalculusOnlyMatrix tests
 @XFAIL

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -16,6 +16,7 @@ from sympy import (
 )
 
 from sympy.utilities.pytest import raises, slow
+from sympy.core.expr import unchanged
 from sympy.core.compatibility import range
 
 from sympy.abc import a, b, x, y, z, r
@@ -138,11 +139,11 @@ def test_CRootOf___eval_Eq__():
     r1 = rootof(eq, 1)
     assert Eq(r, r1) is S.false
     assert Eq(r, r) is S.true
-    assert Eq(r, x).lhs is r and Eq(r, x).rhs is x
+    assert unchanged(Eq, r, x)
     assert Eq(r, 0) is S.false
     assert Eq(r, S.Infinity) is S.false
     assert Eq(r, I) is S.false
-    assert Eq(r, f(0)).lhs is r and Eq(r, f(0)).rhs is f(0)
+    assert unchanged(Eq, r, f(0))
     sol = solve(eq)
     for s in sol:
         if s.is_real:
@@ -572,4 +573,4 @@ def test_eval_approx_relative():
 def test_issue_15920():
     r = rootof(x**5 - x + 1, 0)
     p = Integral(x, (x, 1, y))
-    assert Eq(r, p).lhs is r and Eq(r, p).rhs is p
+    assert unchanged(Eq, r, p)

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -417,20 +417,28 @@ class C89CodePrinter(CodePrinter):
     def _print_Max(self, expr):
         if "Max" in self.known_functions:
             return self._print_Function(expr)
-        from sympy import Max
-        if len(expr.args) == 1:
-            return self._print(expr.args[0])
-        return "((%(a)s > %(b)s) ? %(a)s : %(b)s)" % {
-            'a': expr.args[0], 'b': self._print(Max(*expr.args[1:]))}
+        def inner_print_max(args): # The more natural abstraction of creating
+            if len(args) == 1:     # and printing smaller Max objects is slow
+                return self._print(args[0]) # when there are many arguments.
+            half = len(args) // 2
+            return "((%(a)s > %(b)s) ? %(a)s : %(b)s)" % {
+                'a': inner_print_max(args[:half]),
+                'b': inner_print_max(args[half:])
+            }
+        return inner_print_max(expr.args)
 
     def _print_Min(self, expr):
         if "Min" in self.known_functions:
             return self._print_Function(expr)
-        from sympy import Min
-        if len(expr.args) == 1:
-            return self._print(expr.args[0])
-        return "((%(a)s < %(b)s) ? %(a)s : %(b)s)" % {
-            'a': expr.args[0], 'b': self._print(Min(*expr.args[1:]))}
+        def inner_print_min(args): # The more natural abstraction of creating
+            if len(args) == 1:     # and printing smaller Min objects is slow
+                return self._print(args[0]) # when there are many arguments.
+            half = len(args) // 2
+            return "((%(a)s < %(b)s) ? %(a)s : %(b)s)" % {
+                'a': inner_print_min(args[:half]),
+                'b': inner_print_min(args[half:])
+            }
+        return inner_print_min(expr.args)
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
@@ -696,7 +704,19 @@ class C99CodePrinter(_C9XCodePrinter, C89CodePrinter):
         if nest:
             args = self._print(expr.args[0])
             if len(expr.args) > 1:
-                args += ', %s' % self._print(expr.func(*expr.args[1:]))
+                paren_pile = ''
+                for curr_arg in expr.args[1:-1]:
+                    paren_pile += ')'
+                    args += ', {ns}{name}{suffix}({next}'.format(
+                        ns=self._ns,
+                        name=known,
+                        suffix=suffix,
+                        next = self._print(curr_arg)
+                    )
+                args += ', %s%s' % (
+                    self._print(expr.func(expr.args[-1])),
+                    paren_pile
+                )
         else:
             args = ', '.join(map(lambda arg: self._print(arg), expr.args))
         return '{ns}{name}{suffix}({args})'.format(

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -14,7 +14,7 @@ from sympy.core.operations import AssocOp
 from sympy.core.sympify import SympifyError
 from sympy.logic.boolalg import true
 
-## sympy.printing imports
+# sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
 from sympy.printing.printer import Printer
 from sympy.printing.conventions import split_super_sub, requires_partial
@@ -29,12 +29,14 @@ from sympy.utilities.iterables import has_variety
 import re
 
 # Hand-picked functions which can be used directly in both LaTeX and MathJax
-# Complete list at https://docs.mathjax.org/en/latest/tex.html#supported-latex-commands
+# Complete list at
+# https://docs.mathjax.org/en/latest/tex.html#supported-latex-commands
 # This variable only contains those functions which sympy uses.
 accepted_latex_functions = ['arcsin', 'arccos', 'arctan', 'sin', 'cos', 'tan',
-                    'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec', 'csc',
-                    'cot', 'coth', 're', 'im', 'frac', 'root', 'arg',
-                    ]
+                            'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec',
+                            'csc', 'cot', 'coth', 're', 'im', 'frac', 'root',
+                            'arg',
+                            ]
 
 tex_greek_dictionary = {
     'Alpha': 'A',
@@ -147,7 +149,7 @@ class LatexPrinter(Printer):
                            'equation*']
             if self._settings['mode'] not in valid_modes:
                 raise ValueError("'mode' must be one of 'inline', 'plain', "
-                    "'equation' or 'equation*'")
+                                 "'equation' or 'equation*'")
 
         if self._settings['fold_short_frac'] is None and \
                 self._settings['mode'] == 'inline':
@@ -255,7 +257,8 @@ class LatexPrinter(Printer):
         but also for some container objects that would not need brackets
         when appearing last in a Mul, e.g. an Integral. ``last=True``
         specifies that this expr is the last to appear in a Mul.
-        ``first=True`` specifies that this expr is the first to appear in a Mul.
+        ``first=True`` specifies that this expr is the first to appear in
+        a Mul.
         """
         from sympy import Integral, Product, Sum
 
@@ -271,11 +274,10 @@ class LatexPrinter(Printer):
         if any([expr.has(x) for x in (Mod,)]):
             return True
         if (not last and
-            any([expr.has(x) for x in (Integral, Product, Sum)])):
+                any([expr.has(x) for x in (Integral, Product, Sum)])):
             return True
 
         return False
-
 
     def _needs_add_brackets(self, expr):
         """
@@ -290,7 +292,6 @@ class LatexPrinter(Printer):
         if expr.is_Add:
             return True
         return False
-
 
     def _mul_is_clean(self, expr):
         for arg in expr.args:
@@ -308,8 +309,9 @@ class LatexPrinter(Printer):
             return expr
 
     def _print_Basic(self, expr):
-        l = [self._print(o) for o in expr.args]
-        return self._deal_with_super_sub(expr.__class__.__name__) + r"\left(%s\right)" % ", ".join(l)
+        ls = [self._print(o) for o in expr.args]
+        return self._deal_with_super_sub(expr.__class__.__name__) + \
+            r"\left(%s\right)" % ", ".join(ls)
 
     def _print_bool(self, e):
         return r"\mathrm{%s}" % e
@@ -401,7 +403,7 @@ class LatexPrinter(Printer):
         vec1 = expr._expr1
         vec2 = expr._expr2
         return r"%s \cdot %s" % (self.parenthesize(vec1, PRECEDENCE['Mul']),
-                                  self.parenthesize(vec2, PRECEDENCE['Mul']))
+                                 self.parenthesize(vec2, PRECEDENCE['Mul']))
 
     def _print_Gradient(self, expr):
         func = expr._expr
@@ -438,7 +440,8 @@ class LatexPrinter(Printer):
 
                 # If quantities are present append them at the back
                 args = sorted(args, key=lambda x: isinstance(x, Quantity) or
-                             (isinstance(x, Pow) and isinstance(x.base, Quantity)))
+                              (isinstance(x, Pow) and
+                               isinstance(x.base, Quantity)))
 
                 for i, term in enumerate(args):
                     term_tex = self._print(term)
@@ -468,8 +471,8 @@ class LatexPrinter(Printer):
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
             ratio = self._settings['long_frac_ratio']
-            if self._settings['fold_short_frac'] \
-                   and ldenom <= 2 and not "^" in sdenom:
+            if self._settings['fold_short_frac'] and ldenom <= 2 and \
+                    "^" not in sdenom:
                 # handle short fractions
                 if self._needs_mul_brackets(numer, last=False):
                     tex += r"\left(%s\right) / %s" % (snumer, sdenom)
@@ -509,7 +512,8 @@ class LatexPrinter(Printer):
 
     def _print_Pow(self, expr):
         # Treat x**Rational(1,n) as special case
-        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 and self._settings['root_notation']:
+        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 \
+                and self._settings['root_notation']:
             base = self._print(expr.base)
             expq = expr.exp.q
 
@@ -527,14 +531,16 @@ class LatexPrinter(Printer):
         elif self._settings['fold_frac_powers'] \
             and expr.exp.is_Rational \
                 and expr.exp.q != 1:
-            base, p, q = self.parenthesize(expr.base, PRECEDENCE['Pow']), expr.exp.p, expr.exp.q
+            base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+            p, q = expr.exp.p, expr.exp.q
             # issue #12886: add parentheses for superscripts raised to powers
             if '^' in base and expr.base.is_Symbol:
                 base = r"\left(%s\right)" % base
             if expr.base.is_Function:
                 return self._print(expr.base, exp="%s/%s" % (p, q))
             return r"%s^{%s/%s}" % (base, p, q)
-        elif expr.exp.is_Rational and expr.exp.is_negative and expr.base.is_commutative:
+        elif expr.exp.is_Rational and expr.exp.is_negative and \
+                expr.base.is_commutative:
             # special case for 1^(-x), issue 9216
             if expr.base == 1:
                 return r"%s^{%s}" % (expr.base, expr.exp)
@@ -546,14 +552,15 @@ class LatexPrinter(Printer):
             else:
                 tex = r"%s^{%s}"
                 exp = self._print(expr.exp)
-                # issue #12886: add parentheses around superscripts raised to powers
+                # issue #12886: add parentheses around superscripts raised
+                # to powers
                 base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
                 if '^' in base and expr.base.is_Symbol:
                     base = r"\left(%s\right)" % base
-                elif isinstance(expr.base, Derivative
-                        ) and base.startswith(r'\left('
-                        ) and re.match(r'\\left\(\\d?d?dot', base
-                        ) and base.endswith(r'\right)'):
+                elif (isinstance(expr.base, Derivative)
+                        and base.startswith(r'\left(')
+                        and re.match(r'\\left\(\\d?d?dot', base)
+                        and base.endswith(r'\right)')):
                     # don't use parentheses around dotted derivative
                     base = base[6: -7]  # remove outermost added parens
 
@@ -565,14 +572,14 @@ class LatexPrinter(Printer):
     def _print_Sum(self, expr):
         if len(expr.limits) == 1:
             tex = r"\sum_{%s=%s}^{%s} " % \
-                tuple([ self._print(i) for i in expr.limits[0] ])
+                tuple([self._print(i) for i in expr.limits[0]])
         else:
             def _format_ineq(l):
                 return r"%s \leq %s \leq %s" % \
                     tuple([self._print(s) for s in (l[1], l[0], l[2])])
 
             tex = r"\sum_{\substack{%s}} " % \
-                str.join('\\\\', [ _format_ineq(l) for l in expr.limits ])
+                str.join('\\\\', [_format_ineq(l) for l in expr.limits])
 
         if isinstance(expr.function, Add):
             tex += r"\left(%s\right)" % self._print(expr.function)
@@ -584,14 +591,14 @@ class LatexPrinter(Printer):
     def _print_Product(self, expr):
         if len(expr.limits) == 1:
             tex = r"\prod_{%s=%s}^{%s} " % \
-                tuple([ self._print(i) for i in expr.limits[0] ])
+                tuple([self._print(i) for i in expr.limits[0]])
         else:
             def _format_ineq(l):
                 return r"%s \leq %s \leq %s" % \
                     tuple([self._print(s) for s in (l[1], l[0], l[2])])
 
             tex = r"\prod_{\substack{%s}} " % \
-                str.join('\\\\', [ _format_ineq(l) for l in expr.limits ])
+                str.join('\\\\', [_format_ineq(l) for l in expr.limits])
 
         if isinstance(expr.function, Add):
             tex += r"\left(%s\right)" % self._print(expr.function)
@@ -613,7 +620,7 @@ class LatexPrinter(Printer):
 
         for system, vect in items:
             inneritems = list(vect.components.items())
-            inneritems.sort(key = lambda x:x[0].__str__())
+            inneritems.sort(key=lambda x: x[0].__str__())
             for k, v in inneritems:
                 if v == 1:
                     o1.append(' + ' + k._latex_form)
@@ -659,7 +666,9 @@ class LatexPrinter(Printer):
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, dim, tex)
 
-        return r"%s %s" % (tex, self.parenthesize(expr.expr, PRECEDENCE["Mul"], strict=True))
+        return r"%s %s" % (tex, self.parenthesize(expr.expr,
+                                                  PRECEDENCE["Mul"],
+                                                  strict=True))
 
     def _print_Subs(self, subs):
         expr, old, new = subs.args
@@ -668,7 +677,8 @@ class LatexPrinter(Printer):
         latex_new = (self._print(e) for e in new)
         latex_subs = r'\\ '.join(
             e[0] + '=' + e[1] for e in zip(latex_old, latex_new))
-        return r'\left. %s \right|_{\substack{ %s }}' % (latex_expr, latex_subs)
+        return r'\left. %s \right|_{\substack{ %s }}' % (latex_expr,
+                                                         latex_subs)
 
     def _print_Integral(self, expr):
         tex, symbols = "", []
@@ -699,8 +709,10 @@ class LatexPrinter(Printer):
 
                 symbols.insert(0, r"\, d%s" % self._print(symbol))
 
-        return r"%s %s%s" % (tex,
-            self.parenthesize(expr.function, PRECEDENCE["Mul"], strict=True), "".join(symbols))
+        return r"%s %s%s" % (tex, self.parenthesize(expr.function,
+                                                    PRECEDENCE["Mul"],
+                                                    strict=True),
+                             "".join(symbols))
 
     def _print_Limit(self, expr):
         e, z, z0, dir = expr.args
@@ -747,10 +759,10 @@ class LatexPrinter(Printer):
         '''
         func = expr.func.__name__
         if hasattr(self, '_print_' + func) and \
-            not isinstance(expr, AppliedUndef):
+                not isinstance(expr, AppliedUndef):
             return getattr(self, '_print_' + func)(expr, exp)
         else:
-            args = [ str(self._print(arg)) for arg in expr.args ]
+            args = [str(self._print(arg)) for arg in expr.args]
             # How inverse trig functions should be displayed, formats are:
             # abbreviated: asin, full: arcsin, power: sin^-1
             inv_trig_style = self._settings['inv_trig_style']
@@ -840,7 +852,8 @@ class LatexPrinter(Printer):
     def _hprint_variadic_function(self, expr, exp=None):
         args = sorted(expr.args, key=default_sort_key)
         texargs = [r"%s" % self._print(symbol) for symbol in args]
-        tex = r"\%s\left(%s\right)" % (self._print((str(expr.func)).lower()), ", ".join(texargs))
+        tex = r"\%s\left(%s\right)" % (self._print((str(expr.func)).lower()),
+                                       ", ".join(texargs))
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
         else:
@@ -991,7 +1004,7 @@ class LatexPrinter(Printer):
     def _print_elliptic_pi(self, expr, exp=None):
         if len(expr.args) == 3:
             tex = r"\left(%s; %s\middle| %s\right)" % \
-                (self._print(expr.args[0]), self._print(expr.args[1]), \
+                (self._print(expr.args[0]), self._print(expr.args[1]),
                  self._print(expr.args[2]))
         else:
             tex = r"\left(%s\middle| %s\right)" % \
@@ -1377,7 +1390,8 @@ class LatexPrinter(Printer):
     _print_RandomSymbol = _print_Symbol
 
     def _print_MatrixSymbol(self, expr):
-        return self._print_Symbol(expr, style=self._settings['mat_symbol_style'])
+        return self._print_Symbol(expr,
+                                  style=self._settings['mat_symbol_style'])
 
     def _deal_with_super_sub(self, string):
         if '{' in string:
@@ -1415,7 +1429,7 @@ class LatexPrinter(Printer):
         }
 
         return "%s %s %s" % (self._print(expr.lhs),
-            charmap[expr.rel_op], self._print(expr.rhs))
+                             charmap[expr.rel_op], self._print(expr.rhs))
 
     def _print_Piecewise(self, expr):
         ecpairs = [r"%s & \text{for}\: %s" % (self._print(e), self._print(c))
@@ -1434,7 +1448,7 @@ class LatexPrinter(Printer):
         lines = []
 
         for line in range(expr.rows):  # horrible, should be 'rows'
-            lines.append(" & ".join([ self._print(i) for i in expr[line, :] ]))
+            lines.append(" & ".join([self._print(i) for i in expr[line, :]]))
 
         mat_str = self._settings['mat_str']
         if mat_str is None:
@@ -1461,11 +1475,8 @@ class LatexPrinter(Printer):
                            = _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
-        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) \
-            + '_{%s, %s}' % (
-            self._print(expr.i),
-            self._print(expr.j)
-        )
+        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True)\
+            + '_{%s, %s}' % (self._print(expr.i), self._print(expr.j))
 
     def _print_MatrixSlice(self, expr):
         def latexslice(x):
@@ -1507,7 +1518,8 @@ class LatexPrinter(Printer):
     def _print_MatMul(self, expr):
         from sympy import MatMul, Mul
 
-        parens = lambda x: self.parenthesize(x, precedence_traditional(expr), False)
+        parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
+                                             False)
 
         args = expr.args
         if isinstance(args[0], Mul):
@@ -1526,10 +1538,13 @@ class LatexPrinter(Printer):
 
     def _print_Mod(self, expr, exp=None):
         if exp is not None:
-            return r'\left(%s\bmod{%s}\right)^{%s}' % (self.parenthesize(expr.args[0],
-                    PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]), self._print(exp))
+            return r'\left(%s\bmod{%s}\right)^{%s}' % \
+                (self.parenthesize(expr.args[0], PRECEDENCE['Mul'],
+                                   strict=True), self._print(expr.args[1]),
+                 self._print(exp))
         return r'%s\bmod{%s}' % (self.parenthesize(expr.args[0],
-                PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]))
+                                 PRECEDENCE['Mul'], strict=True),
+                                 self._print(expr.args[1]))
 
     def _print_HadamardProduct(self, expr):
         from sympy import Add, MatAdd, MatMul
@@ -1553,7 +1568,8 @@ class LatexPrinter(Printer):
         base, exp = expr.base, expr.exp
         from sympy.matrices import MatrixSymbol
         if not isinstance(base, MatrixSymbol):
-            return r"\left(%s\right)^{%s}" % (self._print(base), self._print(exp))
+            return r"\left(%s\right)^{%s}" % (self._print(base),
+                                              self._print(exp))
         else:
             return "%s^{%s}" % (self._print(base), self._print(exp))
 
@@ -1583,7 +1599,7 @@ class LatexPrinter(Printer):
             left_delim = self._settings['mat_delim']
             right_delim = self._delim_dict[left_delim]
             block_str = r'\left' + left_delim + block_str + \
-                      r'\right' + right_delim
+                        r'\right' + right_delim
 
         if expr.rank() == 0:
             return block_str % ""
@@ -1597,11 +1613,14 @@ class LatexPrinter(Printer):
                 if len(level_str[back_outer_i+1]) < expr.shape[back_outer_i]:
                     break
                 if even:
-                    level_str[back_outer_i].append(r" & ".join(level_str[back_outer_i+1]))
+                    level_str[back_outer_i].append(
+                        r" & ".join(level_str[back_outer_i+1]))
                 else:
-                    level_str[back_outer_i].append(block_str % (r"\\".join(level_str[back_outer_i+1])))
+                    level_str[back_outer_i].append(
+                        block_str % (r"\\".join(level_str[back_outer_i+1])))
                     if len(level_str[back_outer_i+1]) == 1:
-                        level_str[back_outer_i][-1] = r"\left[" + level_str[back_outer_i][-1] + r"\right]"
+                        level_str[back_outer_i][-1] = r"\left[" + \
+                            level_str[back_outer_i][-1] + r"\right]"
                 even = not even
                 level_str[back_outer_i+1] = []
 
@@ -1623,7 +1642,8 @@ class LatexPrinter(Printer):
         prev_map = None
         for index in indices:
             new_valence = index.is_up
-            if ((index in index_map) or prev_map) and last_valence == new_valence:
+            if ((index in index_map) or prev_map) and \
+                    last_valence == new_valence:
                 out_str += ","
             if last_valence != new_valence:
                 if last_valence is not None:
@@ -1681,7 +1701,7 @@ class LatexPrinter(Printer):
 
     def _print_tuple(self, expr):
         return r"\left( %s\right)" % \
-            r", \  ".join([ self._print(i) for i in expr ])
+            r", \  ".join([self._print(i) for i in expr])
 
     def _print_TensorProduct(self, expr):
         elements = [self._print(a) for a in expr.args]
@@ -1696,7 +1716,7 @@ class LatexPrinter(Printer):
 
     def _print_list(self, expr):
         return r"\left[ %s\right]" % \
-            r", \  ".join([ self._print(i) for i in expr ])
+            r", \  ".join([self._print(i) for i in expr])
 
     def _print_dict(self, d):
         keys = sorted(d.keys(), key=default_sort_key)
@@ -1793,9 +1813,9 @@ class LatexPrinter(Printer):
         else:
             printset = tuple(s)
 
-        return (r"\left\{"
-              + r", ".join(self._print(el) for el in printset)
-              + r"\right\}")
+        return (r"\left\{" +
+                r", ".join(self._print(el) for el in printset) +
+                r"\right\}")
 
     def _print_SeqFormula(self, s):
         if len(s.start.free_symbols) > 0 or len(s.stop.free_symbols) > 0:
@@ -1808,16 +1828,16 @@ class LatexPrinter(Printer):
         if s.start is S.NegativeInfinity:
             stop = s.stop
             printset = (r'\ldots', s.coeff(stop - 3), s.coeff(stop - 2),
-                s.coeff(stop - 1), s.coeff(stop))
+                        s.coeff(stop - 1), s.coeff(stop))
         elif s.stop is S.Infinity or s.length > 4:
             printset = s[:4]
             printset.append(r'\ldots')
         else:
             printset = tuple(s)
 
-        return (r"\left["
-              + r", ".join(self._print(el) for el in printset)
-              + r"\right]")
+        return (r"\left[" +
+                r", ".join(self._print(el) for el in printset) +
+                r"\right]")
 
     _print_SeqPer = _print_SeqFormula
     _print_SeqAdd = _print_SeqFormula
@@ -1878,7 +1898,7 @@ class LatexPrinter(Printer):
     def _print_ImageSet(self, s):
         sets = s.args[1:]
         varsets = [r"%s \in %s" % (self._print(var), self._print(setv))
-            for var, setv in zip(s.lamda.variables, sets)]
+                   for var, setv in zip(s.lamda.variables, sets)]
         return r"\left\{%s\; |\; %s\right\}" % (
             self._print(s.lamda.expr),
             ', '.join(varsets))
@@ -1886,9 +1906,8 @@ class LatexPrinter(Printer):
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])
         if s.base_set is S.UniversalSet:
-            return r"\left\{%s \mid %s \right\}" % (
-            vars_print,
-            self._print(s.condition.as_expr()))
+            return r"\left\{%s \mid %s \right\}" % \
+                (vars_print, self._print(s.condition.as_expr()))
 
         return r"\left\{%s \mid %s \in %s \wedge %s \right\}" % (
             vars_print,
@@ -2011,7 +2030,8 @@ class LatexPrinter(Printer):
         if cls in accepted_latex_functions:
             return r"\%s {\left(%s, %d\right)}" % (cls, expr, index)
         else:
-            return r"\operatorname{%s} {\left(%s, %d\right)}" % (cls, expr, index)
+            return r"\operatorname{%s} {\left(%s, %d\right)}" % (cls, expr,
+                                                                 index)
 
     def _print_RootSum(self, expr):
         cls = expr.__class__.__name__
@@ -2023,7 +2043,8 @@ class LatexPrinter(Printer):
         if cls in accepted_latex_functions:
             return r"\%s {\left(%s\right)}" % (cls, ", ".join(args))
         else:
-            return r"\operatorname{%s} {\left(%s\right)}" % (cls, ", ".join(args))
+            return r"\operatorname{%s} {\left(%s\right)}" % (cls,
+                                                             ", ".join(args))
 
     def _print_PolyElement(self, poly):
         mul_symbol = self._settings['mul_symbol_latex']
@@ -2053,34 +2074,54 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_MellinTransform(self, expr):
-        return r"\mathcal{M}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{M}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseMellinTransform(self, expr):
-        return r"\mathcal{M}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{M}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_LaplaceTransform(self, expr):
-        return r"\mathcal{L}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{L}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseLaplaceTransform(self, expr):
-        return r"\mathcal{L}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{L}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_FourierTransform(self, expr):
-        return r"\mathcal{F}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{F}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseFourierTransform(self, expr):
-        return r"\mathcal{F}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{F}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_SineTransform(self, expr):
-        return r"\mathcal{SIN}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{SIN}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseSineTransform(self, expr):
-        return r"\mathcal{SIN}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{SIN}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_CosineTransform(self, expr):
-        return r"\mathcal{COS}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{COS}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseCosineTransform(self, expr):
-        return r"\mathcal{COS}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{COS}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_DMP(self, p):
         try:
@@ -2175,16 +2216,19 @@ class LatexPrinter(Printer):
     def _print_Quaternion(self, expr):
         # TODO: This expression is potentially confusing,
         # shall we print it as `Quaternion( ... )`?
-        s = [self.parenthesize(i, PRECEDENCE["Mul"], strict=True) for i in expr.args]
+        s = [self.parenthesize(i, PRECEDENCE["Mul"], strict=True)
+             for i in expr.args]
         a = [s[0]] + [i+" "+j for i, j in zip(s[1:], "ijk")]
         return " + ".join(a)
 
     def _print_QuotientRing(self, R):
         # TODO nicer fractions for few generators...
-        return r"\frac{%s}{%s}" % (self._print(R.ring), self._print(R.base_ideal))
+        return r"\frac{%s}{%s}" % (self._print(R.ring),
+                                   self._print(R.base_ideal))
 
     def _print_QuotientRingElement(self, x):
-        return r"{%s} + {%s}" % (self._print(x.data), self._print(x.ring.base_ideal))
+        return r"{%s} + {%s}" % (self._print(x.data),
+                                 self._print(x.ring.base_ideal))
 
     def _print_QuotientModuleElement(self, m):
         return r"{%s} + {%s}" % (self._print(m.data),
@@ -2197,7 +2241,8 @@ class LatexPrinter(Printer):
 
     def _print_MatrixHomomorphism(self, h):
         return r"{%s} : {%s} \to {%s}" % (self._print(h._sympy_matrix()),
-            self._print(h.domain), self._print(h.codomain))
+                                          self._print(h.domain),
+                                          self._print(h.codomain))
 
     def _print_BaseScalarField(self, field):
         string = field._coord_sys._names[field._index]
@@ -2218,20 +2263,20 @@ class LatexPrinter(Printer):
             return r'\mathrm{d}\left(%s\right)' % string
 
     def _print_Tr(self, p):
-        #Todo: Handle indices
+        # TODO: Handle indices
         contents = self._print(p.args[0])
         return r'\mbox{Tr}\left(%s\right)' % (contents)
 
     def _print_totient(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\phi\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\phi\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\phi\left(%s\right)' % self._print(expr.args[0])
 
     def _print_reduced_totient(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\lambda\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\lambda\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\lambda\left(%s\right)' % self._print(expr.args[0])
 
     def _print_divisor_sigma(self, expr, exp=None):
@@ -2256,14 +2301,14 @@ class LatexPrinter(Printer):
 
     def _print_primenu(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\nu\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\nu\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\nu\left(%s\right)' % self._print(expr.args[0])
 
     def _print_primeomega(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\Omega\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\Omega\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
 
 
@@ -2298,11 +2343,11 @@ def translate(s):
 
 
 def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
-    fold_short_frac=None, inv_trig_style="abbreviated",
-    itex=False, ln_notation=False, long_frac_ratio=None,
-    mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
-    order=None, symbol_names=None, root_notation=True,
-    mat_symbol_style="plain", imaginary_unit="i"):
+          fold_short_frac=None, inv_trig_style="abbreviated",
+          itex=False, ln_notation=False, long_frac_ratio=None,
+          mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
+          order=None, symbol_names=None, root_notation=True,
+          mat_symbol_style="plain", imaginary_unit="i"):
     r"""Convert the given expression to LaTeX string representation.
 
     Parameters
@@ -2356,8 +2401,8 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     symbol_names : dictionary of strings mapped to symbols, optional
         Dictionary of symbols and the custom strings they should be emitted as.
     root_notation : boolean, optional
-        If set to ``False``, exponents of the form 1/n are printed in fractonal form.
-        Default is ``True``, to print exponent in root form.
+        If set to ``False``, exponents of the form 1/n are printed in fractonal
+        form. Default is ``True``, to print exponent in root form.
     mat_symbol_style : string, optional
         Can be either ``plain`` (default) or ``bold``. If set to ``bold``,
         a MatrixSymbol A will be printed as ``\mathbf{A}``, otherwise as ``A``.
@@ -2476,22 +2521,22 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
         symbol_names = {}
 
     settings = {
-        'fold_frac_powers' : fold_frac_powers,
-        'fold_func_brackets' : fold_func_brackets,
-        'fold_short_frac' : fold_short_frac,
-        'inv_trig_style' : inv_trig_style,
-        'itex' : itex,
-        'ln_notation' : ln_notation,
-        'long_frac_ratio' : long_frac_ratio,
-        'mat_delim' : mat_delim,
-        'mat_str' : mat_str,
-        'mode' : mode,
-        'mul_symbol' : mul_symbol,
-        'order' : order,
-        'symbol_names' : symbol_names,
-        'root_notation' : root_notation,
-        'mat_symbol_style' : mat_symbol_style,
-        'imaginary_unit' : imaginary_unit,
+        'fold_frac_powers': fold_frac_powers,
+        'fold_func_brackets': fold_func_brackets,
+        'fold_short_frac': fold_short_frac,
+        'inv_trig_style': inv_trig_style,
+        'itex': itex,
+        'ln_notation': ln_notation,
+        'long_frac_ratio': long_frac_ratio,
+        'mat_delim': mat_delim,
+        'mat_str': mat_str,
+        'mode': mode,
+        'mul_symbol': mul_symbol,
+        'order': order,
+        'symbol_names': symbol_names,
+        'root_notation': root_notation,
+        'mat_symbol_style': mat_symbol_style,
+        'imaginary_unit': imaginary_unit,
     }
 
     return LatexPrinter(settings).doprint(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1075,7 +1075,7 @@ class LatexPrinter(Printer):
         tex = r"!%s" % self.parenthesize(expr.args[0], PRECEDENCE["Func"])
 
         if exp is not None:
-            return r"%s^{%s}" % (tex, exp)
+            return r"\left(%s\right)^{%s}" % (tex, exp)
         else:
             return tex
 
@@ -1740,7 +1740,7 @@ class LatexPrinter(Printer):
             tex = r'\delta_{%s %s}' % (i, j)
         else:
             tex = r'\delta_{%s, %s}' % (i, j)
-        if exp:
+        if exp is not None:
             tex = r'\left(%s\right)^{%s}' % (tex, exp)
         return tex
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -405,7 +405,7 @@ class LatexPrinter(Printer):
 
     def _print_Gradient(self, expr):
         func = expr._expr
-        return r"\nabla\cdot %s" % self.parenthesize(func, PRECEDENCE['Mul'])
+        return r"\nabla %s" % self.parenthesize(func, PRECEDENCE['Mul'])
 
     def _print_Mul(self, expr):
         from sympy.core.power import Pow

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -160,6 +160,55 @@ class MCodePrinter(CodePrinter):
 
         return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
 
+    def _print_ImmutableDenseNDimArray(self, expr):
+        return self.doprint(expr.tolist())
+
+    def _print_ImmutableSparseNDimArray(self, expr):
+        def print_string_list(string_list):
+            return '{' + ', '.join(a for a in string_list) + '}'
+
+        def to_mathematica_index(*args):
+            """Helper function to change Python style indexing to
+            Pathematica indexing.
+
+            Python indexing (0, 1 ... n-1)
+            -> Mathematica indexing (1, 2 ... n)
+            """
+            return tuple(i + 1 for i in args)
+
+        def print_rule(pos, val):
+            """Helper function to print a rule of Mathematica"""
+            return '{} -> {}'.format(self.doprint(pos), self.doprint(val))
+
+        def print_data():
+            """Helper function to print data part of Mathematica
+            sparse array.
+
+            It uses the fourth notation ``SparseArray[data,{d1,d2,…}]``
+            from
+            https://reference.wolfram.com/language/ref/SparseArray.html
+
+            ``data`` must be formatted with rule.
+            """
+            return print_string_list(
+                [print_rule(
+                    to_mathematica_index(*(expr._get_tuple_index(key))),
+                    value)
+                for key, value in sorted(expr._sparse_array.items())]
+            )
+
+        def print_dims():
+            """Helper function to print dimensions part of Mathematica
+            sparse array.
+
+            It uses the fourth notation ``SparseArray[data,{d1,d2,…}]``
+            from
+            https://reference.wolfram.com/language/ref/SparseArray.html
+            """
+            return self.doprint(expr.shape)
+
+        return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
+
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
             cond_mfunc = self.known_functions[expr.func.__name__]

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -7,11 +7,11 @@ from __future__ import print_function, division
 from sympy import sympify, S, Mul
 from sympy.core.compatibility import range, string_types, default_sort_key
 from sympy.core.function import _coeff_isneg
-from sympy.core.numbers import E
 from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.precedence import precedence_traditional, PRECEDENCE
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
+
 
 class MathMLPrinterBase(Printer):
     """Contains common code required for MathMLContentPrinter and
@@ -36,12 +36,14 @@ class MathMLPrinterBase(Printer):
 
     def __init__(self, settings=None):
         Printer.__init__(self, settings)
-        from xml.dom.minidom import Document,Text
+        from xml.dom.minidom import Document, Text
 
         self.dom = Document()
 
         # Workaround to allow strings to remain unescaped
-        # Based on https://stackoverflow.com/questions/38015864/python-xml-dom-minidom-please-dont-escape-my-strings/38041194
+        # Based on
+        # https://stackoverflow.com/questions/38015864/python-xml-dom-minidom-\
+        #                              please-dont-escape-my-strings/38041194
         class RawText(Text):
             def writexml(self, writer, indent='', addindent='', newl=''):
                 if self.data:
@@ -68,8 +70,8 @@ class MathMLPrinterBase(Printer):
     def apply_patch(self):
         # Applying the patch of xml.dom.minidom bug
         # Date: 2011-11-18
-        # Description: http://ronrothman.com/public/leftbraned/xml-dom-minidom-\
-        #                   toprettyxml-and-silly-whitespace/#best-solution
+        # Description: http://ronrothman.com/public/leftbraned/xml-dom-minidom\
+        #                   -toprettyxml-and-silly-whitespace/#best-solution
         # Issue: http://bugs.python.org/issue4147
         # Patch: http://hg.python.org/cpython/rev/7262f8f276ff/
 
@@ -393,8 +395,10 @@ class MathMLContentPrinter(MathMLPrinterBase):
     _print_RandomSymbol = _print_Symbol
 
     def _print_Pow(self, e):
-        # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if self._settings['root_notation'] and e.exp.is_Rational and e.exp.p == 1:
+        # Here we use root instead of power if the exponent is the reciprocal
+        # of an integer
+        if (self._settings['root_notation'] and e.exp.is_Rational
+                and e.exp.p == 1):
             x = self.dom.createElement('apply')
             x.appendChild(self.dom.createElement('root'))
             if e.exp.q != 2:
@@ -490,7 +494,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         """Returns the MathML tag for an expression."""
         translate = {
             'Number': 'mn',
-            'Limit' : '&#x2192;',
+            'Limit': '&#x2192;',
             'Derivative': '&dd;',
             'int': 'mn',
             'Symbol': 'mi',
@@ -515,13 +519,14 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             'StrictGreaterThan': '>',
             'StrictLessThan': '<',
             'lerchphi': '&#x3A6;',
-            'BooleanTrue' : 'True',
-            'BooleanFalse' : 'False',
-            'NoneType' : 'None',
+            'BooleanTrue': 'True',
+            'BooleanFalse': 'False',
+            'NoneType': 'None',
         }
 
         def mul_symbol_selection():
-            if self._settings["mul_symbol"] is None or self._settings["mul_symbol"] == 'None':
+            if (self._settings["mul_symbol"] is None or
+                    self._settings["mul_symbol"] == 'None'):
                 return '&InvisibleTimes;'
             elif self._settings["mul_symbol"] == 'times':
                 return '&#xD7;'
@@ -658,7 +663,6 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         else:
             return x
 
-
     def _print_Rational(self, e):
         if e.q == 1:
             # don't divide
@@ -725,7 +729,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return mrow
 
     def _print_Integral(self, expr):
-        intsymbols = {1: "&#x222B;", 2: "&#x222C;", 3: "&#x222D;" }
+        intsymbols = {1: "&#x222B;", 2: "&#x222C;", 3: "&#x222D;"}
 
         mrow = self.dom.createElement('mrow')
         if len(expr.limits) <= 3 and all(len(lim) == 1 for lim in expr.limits):
@@ -752,7 +756,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                     msubsup.appendChild(self._print(lim[2]))
                     mrow.appendChild(msubsup)
         # print function
-        mrow.appendChild(self.parenthesize(expr.function, PRECEDENCE["Mul"], strict=True))
+        mrow.appendChild(self.parenthesize(expr.function, PRECEDENCE["Mul"],
+                                           strict=True))
         # print integration variables
         for lim in reversed(expr.limits):
             d = self.dom.createElement('mo')
@@ -847,7 +852,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
     def _print_MatrixSymbol(self, sym):
-        return self._print_Symbol(sym, style=self._settings['mat_symbol_style'])
+        return self._print_Symbol(sym,
+                                  style=self._settings['mat_symbol_style'])
 
     _print_RandomSymbol = _print_Symbol
 
@@ -881,8 +887,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return brac
 
     def _print_Pow(self, e):
-        # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if e.exp.is_Rational and abs(e.exp.p) == 1 and e.exp.q != 1 and self._settings['root_notation']:
+        # Here we use root instead of power if the exponent is the
+        # reciprocal of an integer
+        if (e.exp.is_Rational and abs(e.exp.p) == 1 and e.exp.q != 1 and
+                self._settings['root_notation']):
             if e.exp.q == 2:
                 x = self.dom.createElement('msqrt')
                 x.appendChild(self._print(e.base))
@@ -904,24 +912,28 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 top.appendChild(self._print(1))
                 x = self.dom.createElement('msup')
                 x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
-                x.appendChild(self._get_printed_Rational(-e.exp, self._settings['fold_frac_powers']))
+                x.appendChild(self._get_printed_Rational(-e.exp,
+                                    self._settings['fold_frac_powers']))
                 top.appendChild(x)
-                return top;
+                return top
             else:
                 x = self.dom.createElement('msup')
                 x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
-                x.appendChild(self._get_printed_Rational(e.exp, self._settings['fold_frac_powers']))
-                return x;
+                x.appendChild(self._get_printed_Rational(e.exp,
+                                    self._settings['fold_frac_powers']))
+                return x
 
         if e.exp.is_negative:
                 top = self.dom.createElement('mfrac')
                 top.appendChild(self._print(1))
-                x = self.dom.createElement('msup')
-                x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
-                x.appendChild(self._print(-e.exp))
-                top.appendChild(x)
-                return top;
-
+                if e.exp == -1:
+                    top.appendChild(self._print(e.base))
+                else:
+                    x = self.dom.createElement('msup')
+                    x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
+                    x.appendChild(self._print(-e.exp))
+                    top.appendChild(x)
+                return top
 
         x = self.dom.createElement('msup')
         x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
@@ -942,7 +954,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
         # Determine denominator
         m = self.dom.createElement('mrow')
-        dim = 0 # Total diff dimension, for numerator
+        dim = 0  # Total diff dimension, for numerator
         for sym, num in reversed(e.variable_count):
             dim += num
             if num >= 2:
@@ -984,7 +996,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_Function(self, e):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mi')
-        if self.mathml_tag(e) == 'log' and self._settings["ln_notation"] == True:
+        if self.mathml_tag(e) == 'log' and self._settings["ln_notation"]:
             x.appendChild(self.dom.createTextNode('ln'))
         else:
             x.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
@@ -1046,8 +1058,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 brac.setAttribute('close', ')')
             else:
                 brac.setAttribute('close', ']')
-            brac.appendChild( self._print(i.start))
-            brac.appendChild( self._print(i.end))
+            brac.appendChild(self._print(i.start))
+            brac.appendChild(self._print(i.end))
 
         mrow.appendChild(brac)
         return mrow
@@ -1249,13 +1261,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         dom_element.appendChild(self.dom.createTextNode(str(p)))
         return dom_element
 
-
     def _print_Integers(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')
         x.appendChild(self.dom.createTextNode('&#x2124;'))
         return x
-
 
     def _print_Complexes(self, e):
         x = self.dom.createElement('mi')
@@ -1263,20 +1273,17 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(self.dom.createTextNode('&#x2102;'))
         return x
 
-
     def _print_Reals(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')
         x.appendChild(self.dom.createTextNode('&#x211D;'))
         return x
 
-
     def _print_Naturals(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')
         x.appendChild(self.dom.createTextNode('&#x2115;'))
         return x
-
 
     def _print_Naturals0(self, e):
         sub = self.dom.createElement('msub')
@@ -1287,15 +1294,13 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         sub.appendChild(self._print(S.Zero))
         return sub
 
-
     def _print_EmptySet(self, e):
         x = self.dom.createElement('mo')
         x.appendChild(self.dom.createTextNode('&#x2205;'))
         return x
 
-
     def _print_floor(self, e):
-        mrow =  self.dom.createElement('mrow')
+        mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
         x.setAttribute('open', u'\u230A')
         x.setAttribute('close', u'\u230B')
@@ -1303,16 +1308,14 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mrow.appendChild(x)
         return mrow
 
-
     def _print_ceiling(self, e):
-        mrow =  self.dom.createElement('mrow')
+        mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
         x.setAttribute('open', u'\u2308')
         x.setAttribute('close', u'\u2309')
         x.appendChild(self._print(e.args[0]))
         mrow.appendChild(x)
         return mrow
-
 
     def _print_Lambda(self, e):
         x = self.dom.createElement('mfenced')
@@ -1330,13 +1333,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(mrow)
         return x
 
-
     def _print_tuple(self, e):
         x = self.dom.createElement('mfenced')
         for i in e:
             x.appendChild(self._print(i))
         return x
-
 
     def _print_IndexedBase(self, e):
         return self._print(e.label)
@@ -1352,8 +1353,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
 
 def mathml(expr, printer='content', **settings):
-    """Returns the MathML representation of expr. If printer is presentation then
-     prints Presentation MathML else prints content MathML.
+    """Returns the MathML representation of expr. If printer is presentation
+    then prints Presentation MathML else prints content MathML.
     """
     if printer == 'presentation':
         return MathMLPresentationPrinter(settings).doprint(expr)
@@ -1397,5 +1398,6 @@ def print_mathml(expr, printer='content', **settings):
 
     print(pretty_xml)
 
-#For backward compatibility
+
+# For backward compatibility
 MathMLPrinter = MathMLContentPrinter

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1271,6 +1271,26 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
 
+    def _print_tuple(self, e):
+        x = self.dom.createElement('mfenced')
+        for i in e:
+            x.appendChild(self._print(i))
+        return x
+
+
+    def _print_IndexedBase(self, e):
+        return self._print(e.label)
+
+    def _print_Indexed(self, e):
+        x = self.dom.createElement('msub')
+        x.appendChild(self._print(e.base))
+        if len(e.indices) == 1:
+            x.appendChild(self._print(e.indices[0]))
+            return x
+        x.appendChild(self._print(e.indices))
+        return x
+
+
 def mathml(expr, printer='content', **settings):
     """Returns the MathML representation of expr. If printer is presentation then
      prints Presentation MathML else prints content MathML.

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -724,42 +724,41 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mrow.appendChild(x)
         return mrow
 
-    def _print_Integral(self, e):
-        limits = list(e.limits)
-        if len(limits[0]) == 3:
-            subsup = self.dom.createElement('msubsup')
-            low_elem = self._print(limits[0][1])
-            up_elem = self._print(limits[0][2])
-            integral = self.dom.createElement('mo')
-            integral.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
-            subsup.appendChild(integral)
-            subsup.appendChild(low_elem)
-            subsup.appendChild(up_elem)
-        if len(limits[0]) == 1:
-            subsup = self.dom.createElement('mrow')
-            integral = self.dom.createElement('mo')
-            integral.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
-            subsup.appendChild(integral)
+    def _print_Integral(self, expr):
+        intsymbols = {1: "&#x222B;", 2: "&#x222C;", 3: "&#x222D;" }
 
         mrow = self.dom.createElement('mrow')
-        diff = self.dom.createElement('mo')
-        diff.appendChild(self.dom.createTextNode('&dd;'))
-        if len(str(limits[0][0])) > 1:
-            var = self.dom.createElement('mfenced')
-            var.appendChild(self._print(limits[0][0]))
+        if len(expr.limits) <= 3 and all(len(lim) == 1 for lim in expr.limits):
+            # Only up to three-integral signs exists
+            mo = self.dom.createElement('mo')
+            mo.appendChild(self.dom.createTextNode(intsymbols[len(expr.limits)]))
+            mrow.appendChild(mo)
         else:
-            var = self._print(limits[0][0])
-
-        mrow.appendChild(subsup)
-        if len(str(e.function)) == 1:
-            mrow.appendChild(self._print(e.function))
-        else:
-            fence = self.dom.createElement('mfenced')
-            fence.appendChild(self._print(e.function))
-            mrow.appendChild(fence)
-
-        mrow.appendChild(diff)
-        mrow.appendChild(var)
+            # Either more than three or limits provided
+            for lim in reversed(expr.limits):
+                mo = self.dom.createElement('mo')
+                mo.appendChild(self.dom.createTextNode(intsymbols[1]))
+                if len(lim) == 1:
+                    mrow.appendChild(mo)
+                if len(lim) == 2:
+                    msup = self.dom.createElement('msup')
+                    msup.appendChild(mo)
+                    msup.appendChild(self._print(lim[1]))
+                    mrow.appendChild(msup)
+                if len(lim) == 3:
+                    msubsup = self.dom.createElement('msubsup')
+                    msubsup.appendChild(mo)
+                    msubsup.appendChild(self._print(lim[1]))
+                    msubsup.appendChild(self._print(lim[2]))
+                    mrow.appendChild(msubsup)
+        # print function
+        mrow.appendChild(self.parenthesize(expr.function, PRECEDENCE["Mul"], strict=True))
+        # print integration variables
+        for lim in reversed(expr.limits):
+            d = self.dom.createElement('mo')
+            d.appendChild(self.dom.createTextNode('&dd;'))
+            mrow.appendChild(d)
+            mrow.appendChild(self._print(lim[0]))
         return mrow
 
     def _print_Sum(self, e):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -138,7 +138,6 @@ class PrettyPrinter(Printer):
         pform = self._print(func)
         pform = prettyForm(*pform.left('('))
         pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('DOT OPERATOR'))))
         pform = prettyForm(*pform.left(self._print(U('NABLA'))))
         return pform
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6182,7 +6182,7 @@ def test_vector_expr_pretty_printing():
 
     assert upretty(Dot(A.i, A.x*A.i+3*A.y*A.j)) == u("(A_i)⋅((A_x) A_i + (3⋅A_y) A_j)")
 
-    assert upretty(Gradient(A.x+3*A.y)) == u("∇⋅(A_x + 3⋅A_y)")
+    assert upretty(Gradient(A.x+3*A.y)) == u("∇(A_x + 3⋅A_y)")
     # TODO: add support for ASCII pretty.
 
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -72,6 +72,14 @@ def test_ccode_Max():
     assert ccode(Max(x,x*x),user_functions={"Max":"my_max", "Pow":"my_pow"}) == 'my_max(x, my_pow(x, 2))'
 
 
+def test_ccode_Min_performance():
+    #Shouldn't take more than a few seconds
+    big_min = Min(*symbols('a[0:50]'))
+    for curr_standard in ('c89', 'c99', 'c11'):
+        output = ccode(big_min, standard=curr_standard)
+        assert output.count('(') == output.count(')')
+
+
 def test_ccode_constants_mathh():
     assert ccode(exp(1)) == "M_E"
     assert ccode(pi) == "M_PI"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,15 +17,17 @@ from sympy import (
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
-     UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
+    UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import (latex, translate, greek_letters_set,
                                   tex_greek_dictionary)
-from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
-                                MutableSparseNDimArray, MutableDenseNDimArray)
+from sympy.tensor.array import (ImmutableDenseNDimArray,
+                                ImmutableSparseNDimArray,
+                                MutableSparseNDimArray,
+                                MutableDenseNDimArray)
 from sympy.tensor.array import tensorproduct
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
@@ -41,8 +43,11 @@ from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
 from sympy.sets.setexpr import SetExpr
 
 import sympy as sym
+
+
 class lowergamma(sym.lowergamma):
     pass   # testing notation inheritance by a subclass with same name
+
 
 x, y, z, t, a, b, c = symbols('x y z t a b c')
 k, m, n = symbols('k m n', integer=True)
@@ -110,7 +115,8 @@ def test_latex_basic():
 
     assert latex(1.5e20*x) == r"1.5 \cdot 10^{20} x"
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
-    assert latex(1.5e20*x, mul_symbol='times') == r"1.5 \times 10^{20} \times x"
+    assert latex(1.5e20*x, mul_symbol='times') == \
+        r"1.5 \times 10^{20} \times x"
 
     assert latex(1/sin(x)) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left(x \right)}}"
@@ -156,31 +162,42 @@ def test_latex_builtins():
 
 
 def test_latex_SingularityFunction():
-    assert latex(SingularityFunction(x, 4, 5)) == r"{\left\langle x - 4 \right\rangle}^{5}"
-    assert latex(SingularityFunction(x, -3, 4)) == r"{\left\langle x + 3 \right\rangle}^{4}"
-    assert latex(SingularityFunction(x, 0, 4)) == r"{\left\langle x \right\rangle}^{4}"
-    assert latex(SingularityFunction(x, a, n)) == r"{\left\langle - a + x \right\rangle}^{n}"
-    assert latex(SingularityFunction(x, 4, -2)) == r"{\left\langle x - 4 \right\rangle}^{-2}"
-    assert latex(SingularityFunction(x, 4, -1)) == r"{\left\langle x - 4 \right\rangle}^{-1}"
+    assert latex(SingularityFunction(x, 4, 5)) == \
+        r"{\left\langle x - 4 \right\rangle}^{5}"
+    assert latex(SingularityFunction(x, -3, 4)) == \
+        r"{\left\langle x + 3 \right\rangle}^{4}"
+    assert latex(SingularityFunction(x, 0, 4)) == \
+        r"{\left\langle x \right\rangle}^{4}"
+    assert latex(SingularityFunction(x, a, n)) == \
+        r"{\left\langle - a + x \right\rangle}^{n}"
+    assert latex(SingularityFunction(x, 4, -2)) == \
+        r"{\left\langle x - 4 \right\rangle}^{-2}"
+    assert latex(SingularityFunction(x, 4, -1)) == \
+        r"{\left\langle x - 4 \right\rangle}^{-1}"
+
 
 def test_latex_cycle():
     assert latex(Cycle(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
-    assert latex(Cycle(1, 2)(4, 5, 6)) == r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
+    assert latex(Cycle(1, 2)(4, 5, 6)) == \
+        r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
     assert latex(Cycle()) == r"\left( \right)"
 
 
 def test_latex_permutation():
     assert latex(Permutation(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
-    assert latex(Permutation(1, 2)(4, 5, 6)) == r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
+    assert latex(Permutation(1, 2)(4, 5, 6)) == \
+        r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
     assert latex(Permutation()) == r"\left( \right)"
-    assert latex(Permutation(2, 4)*Permutation(5)) == r"\left( 2\; 4\right)\left( 5\right)"
+    assert latex(Permutation(2, 4)*Permutation(5)) == \
+        r"\left( 2\; 4\right)\left( 5\right)"
     assert latex(Permutation(5)) == r"\left( 5\right)"
 
 
 def test_latex_Float():
     assert latex(Float(1.0e100)) == r"1.0 \cdot 10^{100}"
     assert latex(Float(1.0e-100)) == r"1.0 \cdot 10^{-100}"
-    assert latex(Float(1.0e-100), mul_symbol="times") == r"1.0 \times 10^{-100}"
+    assert latex(Float(1.0e-100), mul_symbol="times") == \
+        r"1.0 \times 10^{-100}"
     assert latex(1.0*oo) == r"\infty"
     assert latex(-1.0*oo) == r"- \infty"
 
@@ -188,27 +205,43 @@ def test_latex_Float():
 def test_latex_vector_expressions():
     A = CoordSys3D('A')
 
-    assert latex(Cross(A.i, A.j*A.x*3+A.k)) == r"\mathbf{\hat{i}_{A}} \times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
-    assert latex(Cross(A.i, A.j)) == r"\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}"
-    assert latex(x*Cross(A.i, A.j)) == r"x \left(\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}\right)"
-    assert latex(Cross(x*A.i, A.j)) == r'- \mathbf{\hat{j}_{A}} \times \left((x)\mathbf{\hat{i}_{A}}\right)'
+    assert latex(Cross(A.i, A.j*A.x*3+A.k)) == \
+        r"\mathbf{\hat{i}_{A}} \times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+    assert latex(Cross(A.i, A.j)) == \
+        r"\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}"
+    assert latex(x*Cross(A.i, A.j)) == \
+        r"x \left(\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}\right)"
+    assert latex(Cross(x*A.i, A.j)) == \
+        r'- \mathbf{\hat{j}_{A}} \times \left((x)\mathbf{\hat{i}_{A}}\right)'
 
-    assert latex(Curl(3*A.x*A.j)) == r"\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(Curl(3*A.x*A.j+A.i)) == r"\nabla\times \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(Curl(3*x*A.x*A.j)) == r"\nabla\times \left((3 \mathbf{{x}_{A}} x)\mathbf{\hat{j}_{A}}\right)"
-    assert latex(x*Curl(3*A.x*A.j)) == r"x \left(\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
+    assert latex(Curl(3*A.x*A.j)) == \
+        r"\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(Curl(3*A.x*A.j+A.i)) == \
+        r"\nabla\times \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(Curl(3*x*A.x*A.j)) == \
+        r"\nabla\times \left((3 \mathbf{{x}_{A}} x)\mathbf{\hat{j}_{A}}\right)"
+    assert latex(x*Curl(3*A.x*A.j)) == \
+        r"x \left(\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
 
-    assert latex(Divergence(3*A.x*A.j+A.i)) == r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(Divergence(3*A.x*A.j)) == r"\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(x*Divergence(3*A.x*A.j)) == r"x \left(\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
+    assert latex(Divergence(3*A.x*A.j+A.i)) == \
+        r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(Divergence(3*A.x*A.j)) == \
+        r"\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(x*Divergence(3*A.x*A.j)) == \
+        r"x \left(\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
 
-    assert latex(Dot(A.i, A.j*A.x*3+A.k)) == r"\mathbf{\hat{i}_{A}} \cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
-    assert latex(Dot(A.i, A.j)) == r"\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}"
-    assert latex(Dot(x*A.i, A.j)) == r"\mathbf{\hat{j}_{A}} \cdot \left((x)\mathbf{\hat{i}_{A}}\right)"
-    assert latex(x*Dot(A.i, A.j)) == r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
+    assert latex(Dot(A.i, A.j*A.x*3+A.k)) == \
+        r"\mathbf{\hat{i}_{A}} \cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+    assert latex(Dot(A.i, A.j)) == \
+        r"\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}"
+    assert latex(Dot(x*A.i, A.j)) == \
+        r"\mathbf{\hat{j}_{A}} \cdot \left((x)\mathbf{\hat{i}_{A}}\right)"
+    assert latex(x*Dot(A.i, A.j)) == \
+        r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
 
     assert latex(Gradient(A.x)) == r"\nabla \mathbf{{x}_{A}}"
-    assert latex(Gradient(A.x + 3*A.y)) == r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
+    assert latex(Gradient(A.x + 3*A.y)) == \
+        r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
     assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{x}_{A}}\right)"
     assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{x}_{A}} x\right)"
 
@@ -244,8 +277,10 @@ def test_latex_symbols_failing():
     rho, mass, volume = symbols('rho, mass, volume')
     assert latex(
         volume * rho == mass) == r"\rho \mathrm{volume} = \mathrm{mass}"
-    assert latex(volume / mass * rho == 1) == r"\rho \mathrm{volume} {\mathrm{mass}}^{(-1)} = 1"
-    assert latex(mass**3 * volume**3) == r"{\mathrm{mass}}^{3} \cdot {\mathrm{volume}}^{3}"
+    assert latex(volume / mass * rho == 1) == \
+        r"\rho \mathrm{volume} {\mathrm{mass}}^{(-1)} = 1"
+    assert latex(mass**3 * volume**3) == \
+        r"{\mathrm{mass}}^{3} \cdot {\mathrm{volume}}^{3}"
 
 
 def test_latex_functions():
@@ -351,9 +386,12 @@ def test_latex_functions():
     assert latex(Order(x, x)) == r"O\left(x\right)"
     assert latex(Order(x, (x, 0))) == r"O\left(x\right)"
     assert latex(Order(x, (x, oo))) == r"O\left(x; x\rightarrow \infty\right)"
-    assert latex(Order(x - y, (x, y))) == r"O\left(x - y; x\rightarrow y\right)"
-    assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
-    assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
+    assert latex(Order(x - y, (x, y))) == \
+        r"O\left(x - y; x\rightarrow y\right)"
+    assert latex(Order(x, x, y)) == \
+        r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
+    assert latex(Order(x, x, y)) == \
+        r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
     assert latex(Order(x, (x, oo), (y, oo))) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( \infty, \  \infty\right)\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
     assert latex(lowergamma(x, y)**2) == r'\gamma^{2}\left(x, y\right)'
@@ -403,49 +441,56 @@ def test_latex_functions():
     assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left(x \right)}'
     assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}\left(x\right)'
     assert latex(Chi(x)) == r'\operatorname{Chi}\left(x\right)'
-    assert latex(
-        jacobi(n, a, b, x)) == r'P_{n}^{\left(a,b\right)}\left(x\right)'
-    assert latex(jacobi(n, a, b, x)**2) == r'\left(P_{n}^{\left(a,b\right)}\left(x\right)\right)^{2}'
-    assert latex(
-        gegenbauer(n, a, x)) == r'C_{n}^{\left(a\right)}\left(x\right)'
-    assert latex(gegenbauer(n, a, x)**2) == r'\left(C_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
+    assert latex(jacobi(n, a, b, x)) == \
+        r'P_{n}^{\left(a,b\right)}\left(x\right)'
+    assert latex(jacobi(n, a, b, x)**2) == \
+        r'\left(P_{n}^{\left(a,b\right)}\left(x\right)\right)^{2}'
+    assert latex(gegenbauer(n, a, x)) == \
+        r'C_{n}^{\left(a\right)}\left(x\right)'
+    assert latex(gegenbauer(n, a, x)**2) == \
+        r'\left(C_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
     assert latex(chebyshevt(n, x)) == r'T_{n}\left(x\right)'
-    assert latex(
-        chebyshevt(n, x)**2) == r'\left(T_{n}\left(x\right)\right)^{2}'
+    assert latex(chebyshevt(n, x)**2) == \
+        r'\left(T_{n}\left(x\right)\right)^{2}'
     assert latex(chebyshevu(n, x)) == r'U_{n}\left(x\right)'
-    assert latex(
-        chebyshevu(n, x)**2) == r'\left(U_{n}\left(x\right)\right)^{2}'
+    assert latex(chebyshevu(n, x)**2) == \
+        r'\left(U_{n}\left(x\right)\right)^{2}'
     assert latex(legendre(n, x)) == r'P_{n}\left(x\right)'
     assert latex(legendre(n, x)**2) == r'\left(P_{n}\left(x\right)\right)^{2}'
-    assert latex(
-        assoc_legendre(n, a, x)) == r'P_{n}^{\left(a\right)}\left(x\right)'
-    assert latex(assoc_legendre(n, a, x)**2) == r'\left(P_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
+    assert latex(assoc_legendre(n, a, x)) == \
+        r'P_{n}^{\left(a\right)}\left(x\right)'
+    assert latex(assoc_legendre(n, a, x)**2) == \
+        r'\left(P_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
     assert latex(laguerre(n, x)) == r'L_{n}\left(x\right)'
     assert latex(laguerre(n, x)**2) == r'\left(L_{n}\left(x\right)\right)^{2}'
-    assert latex(
-        assoc_laguerre(n, a, x)) == r'L_{n}^{\left(a\right)}\left(x\right)'
-    assert latex(assoc_laguerre(n, a, x)**2) == r'\left(L_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
+    assert latex(assoc_laguerre(n, a, x)) == \
+        r'L_{n}^{\left(a\right)}\left(x\right)'
+    assert latex(assoc_laguerre(n, a, x)**2) == \
+        r'\left(L_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
     assert latex(hermite(n, x)) == r'H_{n}\left(x\right)'
     assert latex(hermite(n, x)**2) == r'\left(H_{n}\left(x\right)\right)^{2}'
 
     theta = Symbol("theta", real=True)
     phi = Symbol("phi", real=True)
-    assert latex(Ynm(n,m,theta,phi)) == r'Y_{n}^{m}\left(\theta,\phi\right)'
-    assert latex(Ynm(n, m, theta, phi)**3) == r'\left(Y_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
-    assert latex(Znm(n,m,theta,phi)) == r'Z_{n}^{m}\left(\theta,\phi\right)'
-    assert latex(Znm(n, m, theta, phi)**3) == r'\left(Z_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
+    assert latex(Ynm(n, m, theta, phi)) == r'Y_{n}^{m}\left(\theta,\phi\right)'
+    assert latex(Ynm(n, m, theta, phi)**3) == \
+        r'\left(Y_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
+    assert latex(Znm(n, m, theta, phi)) == r'Z_{n}^{m}\left(\theta,\phi\right)'
+    assert latex(Znm(n, m, theta, phi)**3) == \
+        r'\left(Z_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
 
     # Test latex printing of function names with "_"
-    assert latex(
-        polar_lift(0)) == r"\operatorname{polar\_lift}{\left(0 \right)}"
-    assert latex(polar_lift(
-        0)**3) == r"\operatorname{polar\_lift}^{3}{\left(0 \right)}"
+    assert latex(polar_lift(0)) == \
+        r"\operatorname{polar\_lift}{\left(0 \right)}"
+    assert latex(polar_lift(0)**3) == \
+        r"\operatorname{polar\_lift}^{3}{\left(0 \right)}"
 
     assert latex(totient(n)) == r'\phi\left(n\right)'
     assert latex(totient(n) ** 2) == r'\left(\phi\left(n\right)\right)^{2}'
 
     assert latex(reduced_totient(n)) == r'\lambda\left(n\right)'
-    assert latex(reduced_totient(n) ** 2) == r'\left(\lambda\left(n\right)\right)^{2}'
+    assert latex(reduced_totient(n) ** 2) == \
+        r'\left(\lambda\left(n\right)\right)^{2}'
 
     assert latex(divisor_sigma(x)) == r"\sigma\left(x\right)"
     assert latex(divisor_sigma(x)**2) == r"\sigma^{2}\left(x\right)"
@@ -461,7 +506,8 @@ def test_latex_functions():
     assert latex(primenu(n) ** 2) == r'\left(\nu\left(n\right)\right)^{2}'
 
     assert latex(primeomega(n)) == r'\Omega\left(n\right)'
-    assert latex(primeomega(n) ** 2) == r'\left(\Omega\left(n\right)\right)^{2}'
+    assert latex(primeomega(n) ** 2) == \
+        r'\left(\Omega\left(n\right)\right)^{2}'
 
     assert latex(Mod(x, 7)) == r'x\bmod{7}'
     assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'
@@ -503,7 +549,8 @@ def test_hyper_printing():
 
 def test_latex_bessel():
     from sympy.functions.special.bessel import (besselj, bessely, besseli,
-            besselk, hankel1, hankel2, jn, yn, hn1, hn2)
+                                                besselk, hankel1, hankel2,
+                                                jn, yn, hn1, hn2)
     from sympy.abc import z
     assert latex(besselj(n, z**2)**k) == r'J^{k}_{n}\left(z^{2}\right)'
     assert latex(bessely(n, z)) == r'Y_{n}\left(z\right)'
@@ -536,12 +583,12 @@ def test_latex_indexed():
     Psi_indexed = IndexedBase(Symbol('Psi', complex=True, real=False))
     symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
-    # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
+    # \\overline{{\\Psi}_{0}} {\\Psi}_{0}  vs.  \\Psi_{0} \\overline{\\Psi_{0}}
     assert symbol_latex == '\\Psi_{0} \\overline{\\Psi_{0}}'
     assert indexed_latex == '\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
-    assert latex(Indexed('x1',Symbol('i'))) == '{x_{1}}_{i}'
+    assert latex(Indexed('x1', Symbol('i'))) == '{x_{1}}_{i}'
     assert latex(IndexedBase('gamma')) == r'\gamma'
     assert latex(IndexedBase('a b')) == 'a b'
     assert latex(IndexedBase('a_b')) == 'a_{b}'
@@ -553,7 +600,8 @@ def test_latex_derivatives():
         r"\frac{d}{d x} x^{3}"
     assert latex(diff(sin(x) + x**2, x, evaluate=False)) == \
         r"\frac{d}{d x} \left(x^{2} + \sin{\left(x \right)}\right)"
-    assert latex(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False)) == \
+    assert latex(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False))\
+        == \
         r"\frac{d^{2}}{d x^{2}} \left(x^{2} + \sin{\left(x \right)}\right)"
     assert latex(diff(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False), evaluate=False)) == \
         r"\frac{d^{3}}{d x^{3}} \left(x^{2} + \sin{\left(x \right)}\right)"
@@ -570,14 +618,14 @@ def test_latex_derivatives():
 
     # mixed partial derivatives
     f = Function("f")
-    assert latex(diff(diff(f(x,y), x, evaluate=False), y, evaluate=False)) == \
-        r"\frac{\partial^{2}}{\partial y\partial x} " + latex(f(x,y))
+    assert latex(diff(diff(f(x, y), x, evaluate=False), y, evaluate=False)) == \
+        r"\frac{\partial^{2}}{\partial y\partial x} " + latex(f(x, y))
 
-    assert latex(diff(diff(diff(f(x,y), x, evaluate=False), x, evaluate=False), y, evaluate=False)) == \
-        r"\frac{\partial^{3}}{\partial y\partial x^{2}} " + latex(f(x,y))
+    assert latex(diff(diff(diff(f(x, y), x, evaluate=False), x, evaluate=False), y, evaluate=False)) == \
+        r"\frac{\partial^{3}}{\partial y\partial x^{2}} " + latex(f(x, y))
 
     # use ordinary d when one of the variables has been integrated out
-    assert latex(diff(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) == \
+    assert latex(diff(Integral(exp(-x*y), (x, 0, oo)), y, evaluate=False)) == \
         r"\frac{d}{d y} \int\limits_{0}^{\infty} e^{- x y}\, dx"
 
     # Derivative wrapped in power:
@@ -598,12 +646,14 @@ def test_latex_subs():
 
 def test_latex_integrals():
     assert latex(Integral(log(x), x)) == r"\int \log{\left(x \right)}\, dx"
-    assert latex(Integral(x**2, (x, 0, 1))) == r"\int\limits_{0}^{1} x^{2}\, dx"
-    assert latex(Integral(x**2, (x, 10, 20))) == r"\int\limits_{10}^{20} x^{2}\, dx"
-    assert latex(Integral(
-        y*x**2, (x, 0, 1), y)) == r"\int\int\limits_{0}^{1} x^{2} y\, dx\, dy"
-    assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*') \
-        == r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\, dx\, dy\end{equation*}"
+    assert latex(Integral(x**2, (x, 0, 1))) == \
+        r"\int\limits_{0}^{1} x^{2}\, dx"
+    assert latex(Integral(x**2, (x, 10, 20))) == \
+        r"\int\limits_{10}^{20} x^{2}\, dx"
+    assert latex(Integral(y*x**2, (x, 0, 1), y)) == \
+        r"\int\int\limits_{0}^{1} x^{2} y\, dx\, dy"
+    assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*') == \
+        r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\, dx\, dy\end{equation*}"
     assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*', itex=True) \
         == r"$$\int\int_{0}^{1} x^{2} y\, dx\, dy$$"
     assert latex(Integral(x, (x, 0))) == r"\int\limits^{0} x\, dx"
@@ -619,7 +669,8 @@ def test_latex_integrals():
     # fix issue #10806
     assert latex(Integral(z, z)**2) == r"\left(\int z\, dz\right)^{2}"
     assert latex(Integral(x + z, z)) == r"\int \left(x + z\right)\, dz"
-    assert latex(Integral(x+z/2, z)) == r"\int \left(x + \frac{z}{2}\right)\, dz"
+    assert latex(Integral(x+z/2, z)) == \
+        r"\int \left(x + \frac{z}{2}\right)\, dz"
     assert latex(Integral(x**y, z)) == r"\int x^{y}\, dz"
 
 
@@ -658,7 +709,8 @@ def test_latex_Range():
 
     assert latex(Range(oo, -2, -2)) == r'\left\{\infty, \ldots, 2, 0\right\}'
 
-    assert latex(Range(-2, -oo, -1)) == r'\left\{-2, -3, \ldots, -\infty\right\}'
+    assert latex(Range(-2, -oo, -1)) == \
+        r'\left\{-2, -3, \ldots, -\infty\right\}'
 
 
 def test_latex_sequences():
@@ -717,8 +769,10 @@ def test_latex_sequences():
     latex_str = r'\left[0, b, 4 b\right]'
     assert latex(s8) == latex_str
 
+
 def test_latex_FourierSeries():
-    latex_str = r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
+    latex_str = \
+        r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
 
 
@@ -741,11 +795,13 @@ def test_latex_AccumuBounds():
     a = Symbol('a', real=True)
     assert latex(AccumBounds(0, 1)) == r"\left\langle 0, 1\right\rangle"
     assert latex(AccumBounds(0, a)) == r"\left\langle 0, a\right\rangle"
-    assert latex(AccumBounds(a + 1, a + 2)) == r"\left\langle a + 1, a + 2\right\rangle"
+    assert latex(AccumBounds(a + 1, a + 2)) == \
+        r"\left\langle a + 1, a + 2\right\rangle"
 
 
 def test_latex_emptyset():
     assert latex(S.EmptySet) == r"\emptyset"
+
 
 def test_latex_commutator():
     A = Operator('A')
@@ -767,12 +823,14 @@ def test_latex_intersection():
 
 
 def test_latex_symmetric_difference():
-    assert latex(SymmetricDifference(Interval(2,5), Interval(4,7), \
-        evaluate = False)) == r'\left[2, 5\right] \triangle \left[4, 7\right]'
+    assert latex(SymmetricDifference(Interval(2, 5), Interval(4, 7),
+                                     evaluate=False)) == \
+        r'\left[2, 5\right] \triangle \left[4, 7\right]'
 
 
 def test_latex_Complement():
-    assert latex(Complement(S.Reals, S.Naturals)) == r"\mathbb{R} \setminus \mathbb{N}"
+    assert latex(Complement(S.Reals, S.Naturals)) == \
+        r"\mathbb{R} \setminus \mathbb{N}"
 
 
 def test_latex_Complexes():
@@ -807,7 +865,8 @@ def test_latex_ImageSet():
         r"\left\{x^{2}\; |\; x \in \mathbb{N}\right\}"
     y = Symbol('y')
     imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
-    assert latex(imgset) == r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\}, y \in \left\{3, 4\right\}\right\}"
+    assert latex(imgset) == \
+        r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\}, y \in \left\{3, 4\right\}\right\}"
 
 
 def test_latex_ConditionSet():
@@ -860,22 +919,28 @@ def test_latex_limits():
     # issue 8175
     f = Function('f')
     assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left(x \right)}"
-    assert latex(Limit(f(x), x, 0, "-")) == r"\lim_{x \to 0^-} f{\left(x \right)}"
+    assert latex(Limit(f(x), x, 0, "-")) == \
+        r"\lim_{x \to 0^-} f{\left(x \right)}"
 
     # issue #10806
-    assert latex(Limit(f(x), x, 0)**2) == r"\left(\lim_{x \to 0^+} f{\left(x \right)}\right)^{2}"
+    assert latex(Limit(f(x), x, 0)**2) == \
+        r"\left(\lim_{x \to 0^+} f{\left(x \right)}\right)^{2}"
     # bi-directional limit
-    assert latex(Limit(f(x), x, 0, dir='+-')) == r"\lim_{x \to 0} f{\left(x \right)}"
+    assert latex(Limit(f(x), x, 0, dir='+-')) == \
+        r"\lim_{x \to 0} f{\left(x \right)}"
 
 
 def test_latex_log():
     assert latex(log(x)) == r"\log{\left(x \right)}"
     assert latex(ln(x)) == r"\log{\left(x \right)}"
     assert latex(log(x), ln_notation=True) == r"\ln{\left(x \right)}"
-    assert latex(log(x)+log(y)) == r"\log{\left(x \right)} + \log{\left(y \right)}"
-    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left(x \right)} + \ln{\left(y \right)}"
-    assert latex(pow(log(x),x)) == r"\log{\left(x \right)}^{x}"
-    assert latex(pow(log(x),x), ln_notation=True) == r"\ln{\left(x \right)}^{x}"
+    assert latex(log(x)+log(y)) == \
+        r"\log{\left(x \right)} + \log{\left(y \right)}"
+    assert latex(log(x)+log(y), ln_notation=True) == \
+        r"\ln{\left(x \right)} + \ln{\left(y \right)}"
+    assert latex(pow(log(x), x)) == r"\log{\left(x \right)}^{x}"
+    assert latex(pow(log(x), x), ln_notation=True) == \
+        r"\ln{\left(x \right)}^{x}"
 
 
 def test_issue_3568():
@@ -899,18 +964,20 @@ def test_latex():
 
 def test_latex_dict():
     d = {Rational(1): 1, x**2: 2, x: 3, x**3: 4}
-    assert latex(d) == r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
+    assert latex(d) == \
+        r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
     D = Dict(d)
-    assert latex(D) == r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
+    assert latex(D) == \
+        r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
 
 
 def test_latex_list():
-    l = [Symbol('omega1'), Symbol('a'), Symbol('alpha')]
-    assert latex(l) == r'\left[ \omega_{1}, \  a, \  \alpha\right]'
+    ll = [Symbol('omega1'), Symbol('a'), Symbol('alpha')]
+    assert latex(ll) == r'\left[ \omega_{1}, \  a, \  \alpha\right]'
 
 
 def test_latex_rational():
-    #tests issue 3973
+    # tests issue 3973
     assert latex(-Rational(1, 2)) == "- \\frac{1}{2}"
     assert latex(Rational(-1, 2)) == "- \\frac{1}{2}"
     assert latex(Rational(1, -2)) == "- \\frac{1}{2}"
@@ -921,7 +988,7 @@ def test_latex_rational():
 
 
 def test_latex_inverse():
-    #tests issue 4129
+    # tests issue 4129
     assert latex(1/x) == "\\frac{1}{x}"
     assert latex(1/(x + y)) == "\\frac{1}{x + y}"
 
@@ -946,12 +1013,14 @@ def test_latex_KroneckerDelta():
     assert latex(KroneckerDelta(x, y + 1)) == r"\delta_{x, y + 1}"
     # issue 6578
     assert latex(KroneckerDelta(x + 1, y)) == r"\delta_{y, x + 1}"
-    assert latex(Pow(KroneckerDelta(x, y), 2, evaluate=False)) == r"\left(\delta_{x y}\right)^{2}"
+    assert latex(Pow(KroneckerDelta(x, y), 2, evaluate=False)) == \
+        r"\left(\delta_{x y}\right)^{2}"
 
 
 def test_latex_LeviCivita():
     assert latex(LeviCivita(x, y, z)) == r"\varepsilon_{x y z}"
-    assert latex(LeviCivita(x, y, z)**2) == r"\left(\varepsilon_{x y z}\right)^{2}"
+    assert latex(LeviCivita(x, y, z)**2) == \
+        r"\left(\varepsilon_{x y z}\right)^{2}"
     assert latex(LeviCivita(x, y, z + 1)) == r"\varepsilon_{x, y, z + 1}"
     assert latex(LeviCivita(x, y + 1, z)) == r"\varepsilon_{x, y + 1, z}"
     assert latex(LeviCivita(x + 1, y, z)) == r"\varepsilon_{x + 1, y, z}"
@@ -966,15 +1035,16 @@ def test_mode():
         expr, mode='equation*') == '\\begin{equation*}x + y\\end{equation*}'
     assert latex(
         expr, mode='equation') == '\\begin{equation}x + y\\end{equation}'
-    raises(ValueError, lambda : latex(expr, mode='foo'))
+    raises(ValueError, lambda: latex(expr, mode='foo'))
 
 
 def test_latex_Piecewise():
     p = Piecewise((x, x < 1), (x**2, True))
     assert latex(p) == "\\begin{cases} x & \\text{for}\\: x < 1 \\\\x^{2} &" \
                        " \\text{otherwise} \\end{cases}"
-    assert latex(p, itex=True) == "\\begin{cases} x & \\text{for}\\: x \\lt 1 \\\\x^{2} &" \
-                                  " \\text{otherwise} \\end{cases}"
+    assert latex(p, itex=True) == \
+        "\\begin{cases} x & \\text{for}\\: x \\lt 1 \\\\x^{2} &" \
+        " \\text{otherwise} \\end{cases}"
     p = Piecewise((x, x < 0), (0, x >= 0))
     assert latex(p) == '\\begin{cases} x & \\text{for}\\: x < 0 \\\\0 &' \
                        ' \\text{otherwise} \\end{cases}'
@@ -984,7 +1054,8 @@ def test_latex_Piecewise():
     assert latex(p) == s
     assert latex(A*p) == r"A \left(%s\right)" % s
     assert latex(p*A) == r"\left(%s\right) A" % s
-    assert latex(Piecewise((x, x < 1), (x**2, x <2))) == '\\begin{cases} x & ' \
+    assert latex(Piecewise((x, x < 1), (x**2, x < 2))) == \
+        '\\begin{cases} x & ' \
         '\\text{for}\\: x < 1 \\\\x^{2} & \\text{for}\\: x < 2 \\end{cases}'
 
 
@@ -1028,7 +1099,8 @@ def test_latex_matrix_with_functions():
 def test_latex_NDimArray():
     x, y, z, w = symbols("x y z w")
 
-    for ArrayType in (ImmutableDenseNDimArray, ImmutableSparseNDimArray, MutableDenseNDimArray, MutableSparseNDimArray):
+    for ArrayType in (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
+                      MutableDenseNDimArray, MutableSparseNDimArray):
         # Basic: scalar array
         M = ArrayType(x)
 
@@ -1040,27 +1112,34 @@ def test_latex_NDimArray():
         M2 = tensorproduct(M1, M)
         M3 = tensorproduct(M, M)
 
-        assert latex(M) == '\\left[\\begin{matrix}\\frac{1}{x} & y\\\\z & w\\end{matrix}\\right]'
-        assert latex(M1) == "\\left[\\begin{matrix}\\frac{1}{x} & y & z\\end{matrix}\\right]"
-        assert latex(M2) == r"\left[\begin{matrix}" \
-                            r"\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & " \
-                            r"\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right] & " \
-                            r"\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right]" \
-                            r"\end{matrix}\right]"
-        assert latex(M3) == r"""\left[\begin{matrix}"""\
-                r"""\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & """\
-                r"""\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right]\\"""\
-                r"""\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right] & """\
-                r"""\left[\begin{matrix}\frac{w}{x} & w y\\w z & w^{2}\end{matrix}\right]"""\
-                r"""\end{matrix}\right]"""
+        assert latex(M) == \
+            '\\left[\\begin{matrix}\\frac{1}{x} & y\\\\z & w\\end{matrix}\\right]'
+        assert latex(M1) == \
+            "\\left[\\begin{matrix}\\frac{1}{x} & y & z\\end{matrix}\\right]"
+        assert latex(M2) == \
+            r"\left[\begin{matrix}" \
+            r"\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & " \
+            r"\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right] & " \
+            r"\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right]" \
+            r"\end{matrix}\right]"
+        assert latex(M3) == \
+            r"""\left[\begin{matrix}"""\
+            r"""\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & """\
+            r"""\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right]\\"""\
+            r"""\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right] & """\
+            r"""\left[\begin{matrix}\frac{w}{x} & w y\\w z & w^{2}\end{matrix}\right]"""\
+            r"""\end{matrix}\right]"""
 
         Mrow = ArrayType([[x, y, 1/z]])
         Mcolumn = ArrayType([[x], [y], [1/z]])
         Mcol2 = ArrayType([Mcolumn.tolist()])
 
-        assert latex(Mrow) == r"\left[\left[\begin{matrix}x & y & \frac{1}{z}\end{matrix}\right]\right]"
-        assert latex(Mcolumn) == r"\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]"
-        assert latex(Mcol2) == r'\left[\begin{matrix}\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]\end{matrix}\right]'
+        assert latex(Mrow) == \
+            r"\left[\left[\begin{matrix}x & y & \frac{1}{z}\end{matrix}\right]\right]"
+        assert latex(Mcolumn) == \
+            r"\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]"
+        assert latex(Mcol2) == \
+            r'\left[\begin{matrix}\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]\end{matrix}\right]'
 
 
 def test_latex_mul_symbol():
@@ -1107,7 +1186,7 @@ def test_latex_pow_fraction():
     # Testing exp
     assert 'e^{-x}' in latex(exp(-x)/2).replace(' ', '')  # Remove Whitespace
 
-    # Testing just e^{-x} in case future changes alter behavior of muls or fracs
+    # Testing e^{-x} in case future changes alter behavior of muls or fracs
     # In particular current output is \frac{1}{2}e^{- x} but perhaps this will
     # change to \frac{e^{-x}}{2}
 
@@ -1131,6 +1210,7 @@ def test_latex_order():
         expr, order='rev-lex') == "y^{4} + 3 x y^{3} + x^{2} y + x^{3}"
     assert latex(expr, order='none') == "x^{3} + y^{4} + y x^{2} + 3 x y^{3}"
 
+
 def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
         r"\left( x \mapsto x + 1 \right)"
@@ -1139,25 +1219,31 @@ def test_latex_Lambda():
 
 
 def test_latex_PolyElement():
-    Ruv, u,v = ring("u,v", ZZ)
-    Rxyz, x,y,z = ring("x,y,z", Ruv)
+    Ruv, u, v = ring("u,v", ZZ)
+    Rxyz, x, y, z = ring("x,y,z", Ruv)
 
     assert latex(x - x) == r"0"
     assert latex(x - 1) == r"x - 1"
     assert latex(x + 1) == r"x + 1"
 
-    assert latex((u**2 + 3*u*v + 1)*x**2*y + u + 1) == r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + u + 1"
-    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x) == r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x"
-    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x + 1) == r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x + 1"
-    assert latex((-u**2 + 3*u*v - 1)*x**2*y - (u + 1)*x - 1) == r"-\left({u}^{2} - 3 u v + 1\right) {x}^{2} y - \left(u + 1\right) x - 1"
+    assert latex((u**2 + 3*u*v + 1)*x**2*y + u + 1) == \
+        r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + u + 1"
+    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x) == \
+        r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x"
+    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x + 1) == \
+        r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x + 1"
+    assert latex((-u**2 + 3*u*v - 1)*x**2*y - (u + 1)*x - 1) == \
+        r"-\left({u}^{2} - 3 u v + 1\right) {x}^{2} y - \left(u + 1\right) x - 1"
 
-    assert latex(-(v**2 + v + 1)*x + 3*u*v + 1) == r"-\left({v}^{2} + v + 1\right) x + 3 u v + 1"
-    assert latex(-(v**2 + v + 1)*x - 3*u*v + 1) == r"-\left({v}^{2} + v + 1\right) x - 3 u v + 1"
+    assert latex(-(v**2 + v + 1)*x + 3*u*v + 1) == \
+        r"-\left({v}^{2} + v + 1\right) x + 3 u v + 1"
+    assert latex(-(v**2 + v + 1)*x - 3*u*v + 1) == \
+        r"-\left({v}^{2} + v + 1\right) x - 3 u v + 1"
 
 
 def test_latex_FracElement():
-    Fuv, u,v = field("u,v", ZZ)
-    Fxyzt, x,y,z,t = field("x,y,z,t", Fuv)
+    Fuv, u, v = field("u,v", ZZ)
+    Fxyzt, x, y, z, t = field("x,y,z,t", Fuv)
 
     assert latex(x - x) == r"0"
     assert latex(x - 1) == r"x - 1"
@@ -1176,8 +1262,10 @@ def test_latex_FracElement():
     assert latex(-y/(x + 1)) == r"\frac{-y}{x + 1}"
     assert latex(y*z/(x + 1)) == r"\frac{y z}{x + 1}"
 
-    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - 1)) == r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - 1}"
-    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - t*u*v - 1)) == r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - u v t - 1}"
+    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - 1)) == \
+        r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - 1}"
+    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - t*u*v - 1)) == \
+        r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - u v t - 1}"
 
 
 def test_latex_Poly():
@@ -1194,7 +1282,8 @@ def test_latex_Poly_order():
         '\\operatorname{Poly}{\\left( a x^{5} + x^{4} + b x^{3} + 2 x^{2} + c x + 3, x, domain=\\mathbb{Z}\\left[a, b, c\\right] \\right)}'
     assert latex(Poly([a, 1, b+c, 2, 3], x)) == \
         '\\operatorname{Poly}{\\left( a x^{4} + x^{3} + \\left(b + c\\right) x^{2} + 2 x + 3, x, domain=\\mathbb{Z}\\left[a, b, c\\right] \\right)}'
-    assert latex(Poly(a*x**3 + x**2*y - x*y - c*y**3 - b*x*y**2 + y - a*x + b, (x, y))) == \
+    assert latex(Poly(a*x**3 + x**2*y - x*y - c*y**3 - b*x*y**2 + y - a*x + b,
+                      (x, y))) == \
         '\\operatorname{Poly}{\\left( a x^{3} + x^{2}y -  b xy^{2} - xy -  a x -  c y^{3} + y + b, x, y, domain=\\mathbb{Z}\\left[a, b, c\\right] \\right)}'
 
 
@@ -1256,24 +1345,24 @@ def test_matMul():
     A = MatrixSymbol('A', 5, 5)
     B = MatrixSymbol('B', 5, 5)
     x = Symbol('x')
-    l = LatexPrinter()
-    assert l._print_MatMul(2*A) == '2 A'
-    assert l._print_MatMul(2*x*A) == '2 x A'
-    assert l._print_MatMul(-2*A) == '- 2 A'
-    assert l._print_MatMul(1.5*A) == '1.5 A'
-    assert l._print_MatMul(sqrt(2)*A) == r'\sqrt{2} A'
-    assert l._print_MatMul(-sqrt(2)*A) == r'- \sqrt{2} A'
-    assert l._print_MatMul(2*sqrt(2)*x*A) == r'2 \sqrt{2} x A'
-    assert l._print_MatMul(-2*A*(A + 2*B)) in [r'- 2 A \left(A + 2 B\right)',
-        r'- 2 A \left(2 B + A\right)']
+    lp = LatexPrinter()
+    assert lp._print_MatMul(2*A) == '2 A'
+    assert lp._print_MatMul(2*x*A) == '2 x A'
+    assert lp._print_MatMul(-2*A) == '- 2 A'
+    assert lp._print_MatMul(1.5*A) == '1.5 A'
+    assert lp._print_MatMul(sqrt(2)*A) == r'\sqrt{2} A'
+    assert lp._print_MatMul(-sqrt(2)*A) == r'- \sqrt{2} A'
+    assert lp._print_MatMul(2*sqrt(2)*x*A) == r'2 \sqrt{2} x A'
+    assert lp._print_MatMul(-2*A*(A + 2*B)) in [r'- 2 A \left(A + 2 B\right)',
+                                                r'- 2 A \left(2 B + A\right)']
 
 
 def test_latex_MatrixSlice():
     from sympy.matrices.expressions import MatrixSymbol
     assert latex(MatrixSymbol('X', 10, 10)[:5, 1:9:2]) == \
-            r'X\left[:5, 1:9:2\right]'
+        r'X\left[:5, 1:9:2\right]'
     assert latex(MatrixSymbol('X', 10, 10)[5, :5:2]) == \
-            r'X\left[5, :5:2\right]'
+        r'X\left[5, :5:2\right]'
 
 
 def test_latex_RandomDomain():
@@ -1307,20 +1396,30 @@ def test_integral_transforms():
     a = Symbol("a")
     b = Symbol("b")
 
-    assert latex(MellinTransform(f(x), x, k)) == r"\mathcal{M}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == r"\mathcal{M}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(MellinTransform(f(x), x, k)) == \
+        r"\mathcal{M}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == \
+        r"\mathcal{M}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(LaplaceTransform(f(x), x, k)) == r"\mathcal{L}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == r"\mathcal{L}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(LaplaceTransform(f(x), x, k)) == \
+        r"\mathcal{L}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == \
+        r"\mathcal{L}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(FourierTransform(f(x), x, k)) == r"\mathcal{F}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseFourierTransform(f(k), k, x)) == r"\mathcal{F}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(FourierTransform(f(x), x, k)) == \
+        r"\mathcal{F}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseFourierTransform(f(k), k, x)) == \
+        r"\mathcal{F}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(CosineTransform(f(x), x, k)) == r"\mathcal{COS}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseCosineTransform(f(k), k, x)) == r"\mathcal{COS}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(CosineTransform(f(x), x, k)) == \
+        r"\mathcal{COS}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseCosineTransform(f(k), k, x)) == \
+        r"\mathcal{COS}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(SineTransform(f(x), x, k)) == \
+        r"\mathcal{SIN}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseSineTransform(f(k), k, x)) == \
+        r"\mathcal{SIN}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
 
 def test_PolynomialRingBase():
@@ -1332,7 +1431,8 @@ def test_PolynomialRingBase():
 
 def test_categories():
     from sympy.categories import (Object, IdentityMorphism,
-        NamedMorphism, Category, Diagram, DiagramGrid)
+                                  NamedMorphism, Category, Diagram,
+                                  DiagramGrid)
 
     A1 = Object("A1")
     A2 = Object("A2")
@@ -1403,21 +1503,24 @@ def test_Modules():
     assert latex(I) == r"\left\langle {x^{2}},{y} \right\rangle"
 
     Q = F / M
-    assert latex(Q) == r"\frac{{\mathbb{Q}\left[x, y\right]}^{2}}{\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}"
+    assert latex(Q) == \
+        r"\frac{{\mathbb{Q}\left[x, y\right]}^{2}}{\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}"
     assert latex(Q.submodule([1, x**3/2], [2, y])) == \
         r"\left\langle {{\left[ {1},{\frac{x^{3}}{2}} \right]} + {\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}},{{\left[ {2},{y} \right]} + {\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}} \right\rangle"
 
-    h = homomorphism(QQ.old_poly_ring(x).free_module(2), QQ.old_poly_ring(x).free_module(2), [0, 0])
+    h = homomorphism(QQ.old_poly_ring(x).free_module(2),
+                     QQ.old_poly_ring(x).free_module(2), [0, 0])
 
-    assert latex(h) == r"{\left[\begin{matrix}0 & 0\\0 & 0\end{matrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
+    assert latex(h) == \
+        r"{\left[\begin{matrix}0 & 0\\0 & 0\end{matrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
 
 
 def test_QuotientRing():
     from sympy.polys.domains import QQ
     R = QQ.old_poly_ring(x)/[x**2 + 1]
 
-    assert latex(
-        R) == r"\frac{\mathbb{Q}\left[x\right]}{\left\langle {x^{2} + 1} \right\rangle}"
+    assert latex(R) == \
+        r"\frac{\mathbb{Q}\left[x\right]}{\left\langle {x^{2} + 1} \right\rangle}"
     assert latex(R.one) == r"{1} + {\left\langle {x^{2} + 1} \right\rangle}"
 
 
@@ -1473,10 +1576,12 @@ def test_boolean_args_order():
     assert latex(expr) == 'a \\vee b \\vee c \\vee d \\vee e \\vee f'
 
     expr = Equivalent(*syms)
-    assert latex(expr) == 'a \\Leftrightarrow b \\Leftrightarrow c \\Leftrightarrow d \\Leftrightarrow e \\Leftrightarrow f'
+    assert latex(expr) == \
+        'a \\Leftrightarrow b \\Leftrightarrow c \\Leftrightarrow d \\Leftrightarrow e \\Leftrightarrow f'
 
     expr = Xor(*syms)
-    assert latex(expr) == 'a \\veebar b \\veebar c \\veebar d \\veebar e \\veebar f'
+    assert latex(expr) == \
+        'a \\veebar b \\veebar c \\veebar d \\veebar e \\veebar f'
 
 
 def test_imaginary():
@@ -1540,7 +1645,8 @@ def test_other_symbols():
 
 
 def test_modifiers():
-    # Test each modifier individually in the simplest case (with funny capitalizations)
+    # Test each modifier individually in the simplest case
+    # (with funny capitalizations)
     assert latex(symbols("xMathring")) == r"\mathring{x}"
     assert latex(symbols("xCheck")) == r"\check{x}"
     assert latex(symbols("xBreve")) == r"\breve{x}"
@@ -1588,8 +1694,10 @@ def test_modifiers():
     assert latex(symbols("xDotVec")) == r"\vec{\dot{x}}"
     assert latex(symbols("xHATNorm")) == r"\left\|{\hat{x}}\right\|"
     # Check a couple big, ugly combinations
-    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == r"\boldsymbol{\mathring{x}}^{\left|{\breve{z}}\right|}_{{\check{y}}'}"
-    assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"
+    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == \
+        r"\boldsymbol{\mathring{x}}^{\left|{\breve{z}}\right|}_{{\check{y}}'}"
+    assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == \
+        r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"
 
 
 def test_greek_symbols():
@@ -1673,25 +1781,25 @@ def test_issue_6853():
 
 def test_Mul():
     e = Mul(-2, x + 1, evaluate=False)
-    assert latex(e)  == r'- 2 \left(x + 1\right)'
+    assert latex(e) == r'- 2 \left(x + 1\right)'
     e = Mul(2, x + 1, evaluate=False)
-    assert latex(e)  == r'2 \left(x + 1\right)'
+    assert latex(e) == r'2 \left(x + 1\right)'
     e = Mul(S.One/2, x + 1, evaluate=False)
-    assert latex(e)  == r'\frac{x + 1}{2}'
+    assert latex(e) == r'\frac{x + 1}{2}'
     e = Mul(y, x + 1, evaluate=False)
-    assert latex(e)  == r'y \left(x + 1\right)'
+    assert latex(e) == r'y \left(x + 1\right)'
     e = Mul(-y, x + 1, evaluate=False)
-    assert latex(e)  == r'- y \left(x + 1\right)'
+    assert latex(e) == r'- y \left(x + 1\right)'
     e = Mul(-2, x + 1)
-    assert latex(e)  == r'- 2 x - 2'
+    assert latex(e) == r'- 2 x - 2'
     e = Mul(2, x + 1)
-    assert latex(e)  == r'2 x + 2'
+    assert latex(e) == r'2 x + 2'
 
 
 def test_Pow():
     e = Pow(2, 2, evaluate=False)
-    assert latex(e)  == r'2^{2}'
-    assert latex(x**(Rational(-1,3))) == r'\frac{1}{\sqrt[3]{x}}'
+    assert latex(e) == r'2^{2}'
+    assert latex(x**(Rational(-1, 3))) == r'\frac{1}{\sqrt[3]{x}}'
     x2 = Symbol(r'x^2')
     assert latex(x2**2) == r'\left(x^{2}\right)^{2}'
 
@@ -1743,7 +1851,8 @@ def test_issue_10489():
 
 def test_issue_12886():
     m__1, l__1 = symbols('m__1, l__1')
-    assert latex(m__1**2 + l__1**2) == r'\left(l^{1}\right)^{2} + \left(m^{1}\right)^{2}'
+    assert latex(m__1**2 + l__1**2) == \
+        r'\left(l^{1}\right)^{2} + \left(m^{1}\right)^{2}'
 
 
 def test_issue_13559():
@@ -1781,7 +1890,8 @@ def test_MatrixElement_printing():
     i, j, k = symbols("i j k")
     M = MatrixSymbol("M", k, k)
     N = MatrixSymbol("N", k, k)
-    assert latex((M*N)[i, j]) == r'\sum_{i_{1}=0}^{k - 1} M_{i, i_{1}} N_{i_{1}, j}'
+    assert latex((M*N)[i, j]) == \
+        r'\sum_{i_{1}=0}^{k - 1} M_{i, i_{1}} N_{i_{1}, j}'
 
 
 def test_MatrixSymbol_printing():
@@ -1804,9 +1914,9 @@ def test_KroneckerProduct_printing():
 def test_Quaternion_latex_printing():
     q = Quaternion(x, y, z, t)
     assert latex(q) == "x + y i + z j + t k"
-    q = Quaternion(x,y,z,x*t)
+    q = Quaternion(x, y, z, x*t)
     assert latex(q) == "x + y i + z j + t x k"
-    q = Quaternion(x,y,z,x+t)
+    q = Quaternion(x, y, z, x + t)
     assert latex(q) == r"x + y i + z j + \left(t + x\right) k"
 
 
@@ -1828,7 +1938,7 @@ def test_issue_14041():
     import sympy.physics.mechanics as me
 
     A_frame = me.ReferenceFrame('A')
-    thetad, phid  = me.dynamicsymbols('theta, phi', 1)
+    thetad, phid = me.dynamicsymbols('theta, phi', 1)
     L = Symbol('L')
 
     assert latex(L*(phid + thetad)**2*A_frame.x) == \
@@ -1851,6 +1961,7 @@ def test_issue_9216():
 
     expr_4 = Pow(1, -2, evaluate=False)
     assert latex(expr_4) == r"1^{-2}"
+
 
 def test_latex_printer_tensor():
     from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
@@ -1906,25 +2017,25 @@ def test_latex_printer_tensor():
     expr = A(i) + 3*B(i)
     assert latex(expr) == "3B{}^{i} + A{}^{i}"
 
-    ## Test ``TensorElement``:
+    # Test ``TensorElement``:
     from sympy.tensor.tensor import TensorElement
 
-    expr = TensorElement(K(i,j,k,l), {i:3, k:2})
+    expr = TensorElement(K(i, j, k, l), {i: 3, k: 2})
     assert latex(expr) == 'K{}^{i=3,j,k=2,l}'
 
-    expr = TensorElement(K(i,j,k,l), {i:3})
+    expr = TensorElement(K(i, j, k, l), {i: 3})
     assert latex(expr) == 'K{}^{i=3,jkl}'
 
-    expr = TensorElement(K(i,-j,k,l), {i:3, k:2})
+    expr = TensorElement(K(i, -j, k, l), {i: 3, k: 2})
     assert latex(expr) == 'K{}^{i=3}{}_{j}{}^{k=2,l}'
 
-    expr = TensorElement(K(i,-j,k,-l), {i:3, k:2})
+    expr = TensorElement(K(i, -j, k, -l), {i: 3, k: 2})
     assert latex(expr) == 'K{}^{i=3}{}_{j}{}^{k=2}{}_{l}'
 
-    expr = TensorElement(K(i,j,-k,-l), {i:3, -k:2})
+    expr = TensorElement(K(i, j, -k, -l), {i: 3, -k: 2})
     assert latex(expr) == 'K{}^{i=3,j}{}_{k=2,l}'
 
-    expr = TensorElement(K(i,j,-k,-l), {i:3})
+    expr = TensorElement(K(i, j, -k, -l), {i: 3})
     assert latex(expr) == 'K{}^{i=3,j}{}_{kl}'
 
 
@@ -1933,7 +2044,8 @@ def test_issue_15353():
     a, x = symbols('a x')
     # Obtained from nonlinsolve([(sin(a*x)),cos(a*x)],[x,a])
     sol = ConditionSet(Tuple(x, a), FiniteSet(sin(a*x), cos(a*x)), S.Complexes)
-    assert latex(sol) == r'\left\{\left( x, \  a\right) \mid \left( x, \  a\right) \in \mathbb{C} \wedge \left\{\sin{\left(a x \right)}, \cos{\left(a x \right)}\right\} \right\}'
+    assert latex(sol) == \
+        r'\left\{\left( x, \  a\right) \mid \left( x, \  a\right) \in \mathbb{C} \wedge \left\{\sin{\left(a x \right)}, \cos{\left(a x \right)}\right\} \right\}'
 
 
 def test_trace():
@@ -1948,7 +2060,8 @@ def test_print_basic():
     # Issue 15303
     from sympy import Basic, Expr
 
-    # dummy class for testing printing where the function is not implemented in latex.py
+    # dummy class for testing printing where the function is not
+    # implemented in latex.py
     class UnimplementedExpr(Expr):
         def __new__(cls, e):
             return Basic.__new__(cls, e)
@@ -1964,24 +2077,30 @@ def test_print_basic():
         return result
 
     assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
-    assert latex(unimplemented_expr(x**2)) == r'UnimplementedExpr\left(x^{2}\right)'
-    assert latex(unimplemented_expr_sup_sub(x)) == r'UnimplementedExpr^{1}_{x}\left(x\right)'
+    assert latex(unimplemented_expr(x**2)) == \
+        r'UnimplementedExpr\left(x^{2}\right)'
+    assert latex(unimplemented_expr_sup_sub(x)) == \
+        r'UnimplementedExpr^{1}_{x}\left(x\right)'
 
 
 def test_MatrixSymbol_bold():
     # Issue #15871
     from sympy import trace
     A = MatrixSymbol("A", 2, 2)
-    assert latex(trace(A), mat_symbol_style='bold') == r"\mathrm{tr}\left(\mathbf{A} \right)"
-    assert latex(trace(A), mat_symbol_style='plain') == r"\mathrm{tr}\left(A \right)"
+    assert latex(trace(A), mat_symbol_style='bold') == \
+        r"\mathrm{tr}\left(\mathbf{A} \right)"
+    assert latex(trace(A), mat_symbol_style='plain') == \
+        r"\mathrm{tr}\left(A \right)"
 
     A = MatrixSymbol("A", 3, 3)
     B = MatrixSymbol("B", 3, 3)
     C = MatrixSymbol("C", 3, 3)
 
     assert latex(-A, mat_symbol_style='bold') == r"- \mathbf{A}"
-    assert latex(A - A*B - B, mat_symbol_style='bold') == r"\mathbf{A} - \mathbf{A} \mathbf{B} - \mathbf{B}"
-    assert latex(-A*B - A*B*C - B, mat_symbol_style='bold') == r"- \mathbf{A} \mathbf{B} - \mathbf{A} \mathbf{B} \mathbf{C} - \mathbf{B}"
+    assert latex(A - A*B - B, mat_symbol_style='bold') == \
+        r"\mathbf{A} - \mathbf{A} \mathbf{B} - \mathbf{B}"
+    assert latex(-A*B - A*B*C - B, mat_symbol_style='bold') == \
+        r"- \mathbf{A} \mathbf{B} - \mathbf{A} \mathbf{B} \mathbf{C} - \mathbf{B}"
 
     A = MatrixSymbol("A_k", 3, 3)
     assert latex(A, mat_symbol_style='bold') == r"\mathbf{A_{k}}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,7 +17,7 @@ from sympy import (
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
-     UnevaluatedExpr, Quaternion, I)
+     UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -272,6 +272,7 @@ def test_latex_functions():
     # not to be confused with the beta function
     assert latex(mybeta(x, y, z)) == r"\beta{\left(x,y,z \right)}"
     assert latex(beta(x, y)) == r'\operatorname{B}\left(x, y\right)'
+    assert latex(beta(x, y)**2) == r'\operatorname{B}^{2}\left(x, y\right)'
     assert latex(mybeta(x)) == r"\beta{\left(x \right)}"
     assert latex(mybeta) == r"\beta"
 
@@ -311,29 +312,38 @@ def test_latex_functions():
 
     assert latex(factorial(k)) == r"k!"
     assert latex(factorial(-k)) == r"\left(- k\right)!"
+    assert latex(factorial(k)**2) == r"k!^{2}"
 
     assert latex(subfactorial(k)) == r"!k"
     assert latex(subfactorial(-k)) == r"!\left(- k\right)"
+    assert latex(subfactorial(k)**2) == r"\left(!k\right)^{2}"
 
     assert latex(factorial2(k)) == r"k!!"
     assert latex(factorial2(-k)) == r"\left(- k\right)!!"
+    assert latex(factorial2(k)**2) == r"k!!^{2}"
 
     assert latex(binomial(2, k)) == r"{\binom{2}{k}}"
+    assert latex(binomial(2, k)**2) == r"{\binom{2}{k}}^{2}"
 
     assert latex(FallingFactorial(3, k)) == r"{\left(3\right)}_{k}"
     assert latex(RisingFactorial(3, k)) == r"{3}^{\left(k\right)}"
 
     assert latex(floor(x)) == r"\left\lfloor{x}\right\rfloor"
     assert latex(ceiling(x)) == r"\left\lceil{x}\right\rceil"
+    assert latex(floor(x)**2) == r"\left\lfloor{x}\right\rfloor^{2}"
+    assert latex(ceiling(x)**2) == r"\left\lceil{x}\right\rceil^{2}"
     assert latex(Min(x, 2, x**3)) == r"\min\left(2, x, x^{3}\right)"
     assert latex(Min(x, y)**2) == r"\min\left(x, y\right)^{2}"
     assert latex(Max(x, 2, x**3)) == r"\max\left(2, x, x^{3}\right)"
     assert latex(Max(x, y)**2) == r"\max\left(x, y\right)^{2}"
     assert latex(Abs(x)) == r"\left|{x}\right|"
+    assert latex(Abs(x)**2) == r"\left|{x}\right|^{2}"
     assert latex(re(x)) == r"\Re{\left(x\right)}"
     assert latex(re(x + y)) == r"\Re{\left(x\right)} + \Re{\left(y\right)}"
     assert latex(im(x)) == r"\Im{x}"
     assert latex(conjugate(x)) == r"\overline{x}"
+    assert latex(conjugate(x)**2) == r"\overline{x}^{2}"
+    assert latex(conjugate(x**2)) == r"\overline{x}^{2}"
     assert latex(gamma(x)) == r"\Gamma\left(x\right)"
     w = Wild('w')
     assert latex(gamma(w)) == r"\Gamma\left(w\right)"
@@ -346,7 +356,9 @@ def test_latex_functions():
     assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
     assert latex(Order(x, (x, oo), (y, oo))) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( \infty, \  \infty\right)\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
+    assert latex(lowergamma(x, y)**2) == r'\gamma^{2}\left(x, y\right)'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
+    assert latex(uppergamma(x, y)**2) == r'\Gamma^{2}\left(x, y\right)'
 
     assert latex(cot(x)) == r'\cot{\left(x \right)}'
     assert latex(coth(x)) == r'\coth{\left(x \right)}'
@@ -384,6 +396,7 @@ def test_latex_functions():
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
     assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'
+    assert latex(expint(x, y)) == r'\operatorname{E}_{x}\left(y\right)'
     assert latex(expint(x, y)**2) == r'\operatorname{E}_{x}^{2}\left(y\right)'
     assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left(x \right)}'
     assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left(x \right)}'
@@ -748,6 +761,11 @@ def test_latex_union():
         r"\left\{1, 2\right\} \cup \left[3, 4\right]"
 
 
+def test_latex_intersection():
+    assert latex(Intersection(Interval(0, 1), Interval(x, y))) == \
+        r"\left[0, 1\right] \cap \left[x, y\right]"
+
+
 def test_latex_symmetric_difference():
     assert latex(SymmetricDifference(Interval(2,5), Interval(4,7), \
         evaluate = False)) == r'\left[2, 5\right] \triangle \left[4, 7\right]'
@@ -928,6 +946,7 @@ def test_latex_KroneckerDelta():
     assert latex(KroneckerDelta(x, y + 1)) == r"\delta_{x, y + 1}"
     # issue 6578
     assert latex(KroneckerDelta(x + 1, y)) == r"\delta_{y, x + 1}"
+    assert latex(Pow(KroneckerDelta(x, y), 2, evaluate=False)) == r"\left(\delta_{x y}\right)^{2}"
 
 
 def test_latex_LeviCivita():
@@ -947,6 +966,7 @@ def test_mode():
         expr, mode='equation*') == '\\begin{equation*}x + y\\end{equation*}'
     assert latex(
         expr, mode='equation') == '\\begin{equation}x + y\\end{equation}'
+    raises(ValueError, lambda : latex(expr, mode='foo'))
 
 
 def test_latex_Piecewise():
@@ -964,6 +984,8 @@ def test_latex_Piecewise():
     assert latex(p) == s
     assert latex(A*p) == r"A \left(%s\right)" % s
     assert latex(p*A) == r"\left(%s\right) A" % s
+    assert latex(Piecewise((x, x < 1), (x**2, x <2))) == '\\begin{cases} x & ' \
+        '\\text{for}\\: x < 1 \\\\x^{2} & \\text{for}\\: x < 2 \\end{cases}'
 
 
 def test_latex_Matrix():
@@ -1102,12 +1124,12 @@ def test_noncommutative():
 
 
 def test_latex_order():
-    expr = x**3 + x**2*y + 3*x*y**3 + y**4
+    expr = x**3 + x**2*y + y**4 + 3*x*y**3
 
     assert latex(expr, order='lex') == "x^{3} + x^{2} y + 3 x y^{3} + y^{4}"
     assert latex(
         expr, order='rev-lex') == "y^{4} + 3 x y^{3} + x^{2} y + x^{3}"
-
+    assert latex(expr, order='none') == "x^{3} + y^{4} + y x^{2} + 3 x y^{3}"
 
 def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
@@ -1436,6 +1458,11 @@ def test_ZeroMatrix():
     assert latex(ZeroMatrix(1, 1)) == r"\mathbb{0}"
 
 
+def test_Identity():
+    from sympy import Identity
+    assert latex(Identity(1)) == r"\mathbb{I}"
+
+
 def test_boolean_args_order():
     syms = symbols('a:f')
 
@@ -1664,6 +1691,9 @@ def test_Mul():
 def test_Pow():
     e = Pow(2, 2, evaluate=False)
     assert latex(e)  == r'2^{2}'
+    assert latex(x**(Rational(-1,3))) == r'\frac{1}{\sqrt[3]{x}}'
+    x2 = Symbol(r'x^2')
+    assert latex(x2**2) == r'\left(x^{2}\right)^{2}'
 
 
 def test_issue_7180():
@@ -1763,6 +1793,12 @@ def test_MatrixSymbol_printing():
     assert latex(-A) == r"- A"
     assert latex(A - A*B - B) == r"A - A B - B"
     assert latex(-A*B - A*B*C - B) == r"- A B - A B C - B"
+
+
+def test_KroneckerProduct_printing():
+    A = MatrixSymbol('A', 3, 3)
+    B = MatrixSymbol('B', 2, 2)
+    assert latex(KroneckerProduct(A, B)) == r'A \otimes B'
 
 
 def test_Quaternion_latex_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -207,10 +207,10 @@ def test_latex_vector_expressions():
     assert latex(Dot(x*A.i, A.j)) == r"\mathbf{\hat{j}_{A}} \cdot \left((x)\mathbf{\hat{i}_{A}}\right)"
     assert latex(x*Dot(A.i, A.j)) == r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
 
-    assert latex(Gradient(A.x)) == r"\nabla\cdot \mathbf{{x}_{A}}"
-    assert latex(Gradient(A.x + 3*A.y)) == r"\nabla\cdot \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
-    assert latex(x*Gradient(A.x)) == r"x \left(\nabla\cdot \mathbf{{x}_{A}}\right)"
-    assert latex(Gradient(x*A.x)) == r"\nabla\cdot \left(\mathbf{{x}_{A}} x\right)"
+    assert latex(Gradient(A.x)) == r"\nabla \mathbf{{x}_{A}}"
+    assert latex(Gradient(A.x + 3*A.y)) == r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
+    assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{x}_{A}}\right)"
+    assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{x}_{A}} x\right)"
 
 
 def test_latex_symbols():

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -113,6 +113,58 @@ def test_matrices():
     assert mcode(MutableDenseMatrix(3, 0, [])) == '{{}, {}, {}}'
     assert mcode(MutableSparseMatrix(3, 0, [])) == 'SparseArray[{}, {3, 0}]'
 
+def test_NDArray():
+    from sympy.tensor.array import (
+        MutableDenseNDimArray, ImmutableDenseNDimArray,
+        MutableSparseNDimArray, ImmutableSparseNDimArray)
+
+    example = MutableDenseNDimArray(
+        [[[1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12]],
+         [[13, 14, 15, 16],
+          [17, 18, 19, 20],
+          [21, 22, 23, 24]]]
+    )
+
+    assert mcode(example) == \
+    "{{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}, " \
+    "{{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}}"
+
+    example = ImmutableDenseNDimArray(example)
+
+    assert mcode(example) == \
+    "{{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}, " \
+    "{{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}}"
+
+    example = MutableSparseNDimArray(example)
+
+    assert mcode(example) == \
+    "SparseArray[{" \
+        "{1, 1, 1} -> 1, {1, 1, 2} -> 2, {1, 1, 3} -> 3, " \
+        "{1, 1, 4} -> 4, {1, 2, 1} -> 5, {1, 2, 2} -> 6, " \
+        "{1, 2, 3} -> 7, {1, 2, 4} -> 8, {1, 3, 1} -> 9, " \
+        "{1, 3, 2} -> 10, {1, 3, 3} -> 11, {1, 3, 4} -> 12, " \
+        "{2, 1, 1} -> 13, {2, 1, 2} -> 14, {2, 1, 3} -> 15, " \
+        "{2, 1, 4} -> 16, {2, 2, 1} -> 17, {2, 2, 2} -> 18, " \
+        "{2, 2, 3} -> 19, {2, 2, 4} -> 20, {2, 3, 1} -> 21, " \
+        "{2, 3, 2} -> 22, {2, 3, 3} -> 23, {2, 3, 4} -> 24" \
+        "}, {2, 3, 4}]"
+
+    example = ImmutableSparseNDimArray(example)
+
+    assert mcode(example) == \
+    "SparseArray[{" \
+        "{1, 1, 1} -> 1, {1, 1, 2} -> 2, {1, 1, 3} -> 3, " \
+        "{1, 1, 4} -> 4, {1, 2, 1} -> 5, {1, 2, 2} -> 6, " \
+        "{1, 2, 3} -> 7, {1, 2, 4} -> 8, {1, 3, 1} -> 9, " \
+        "{1, 3, 2} -> 10, {1, 3, 3} -> 11, {1, 3, 4} -> 12, " \
+        "{2, 1, 1} -> 13, {2, 1, 2} -> 14, {2, 1, 3} -> 15, " \
+        "{2, 1, 4} -> 16, {2, 2, 1} -> 17, {2, 2, 2} -> 18, " \
+        "{2, 2, 3} -> 19, {2, 2, 4} -> 20, {2, 3, 1} -> 21, " \
+        "{2, 3, 2} -> 22, {2, 3, 3} -> 23, {2, 3, 4} -> 24" \
+        "}, {2, 3, 4}]"
+
 
 def test_Integral():
     assert mcode(Integral(sin(sin(x)), x)) == "Hold[Integrate[Sin[Sin[x]], x]]"

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,13 +1,13 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, S, \
-    MatrixSymbol, Function, Derivative, log, Lambda, IndexedBase, symbols
+    MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
+    Lambda, IndexedBase, symbols
 from sympy.core.containers import Tuple
-from sympy.functions.elementary.complexes import re, im, Abs, conjugate
-from sympy.functions.elementary.integers import floor, ceiling
-from sympy.functions.elementary.exponential import exp
 from sympy.functions.combinatorial.factorials import factorial, factorial2, binomial
-from sympy.functions.elementary.complexes import conjugate
+from sympy.functions.elementary.complexes import re, im, Abs, conjugate
+from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.zeta_functions import polylog, lerchphi
 from sympy.logic.boolalg import And, Or, Implies, Equivalent, Xor, Not
 from sympy.matrices.expressions.determinant import Determinant
@@ -16,7 +16,6 @@ from sympy.printing.mathml import mathml, MathMLContentPrinter, MathMLPresentati
 from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, SymmetricDifference
 from sympy.stats.rv import RandomSymbol
 from sympy.sets.sets import Interval
-from sympy.stats.rv import RandomSymbol
 from sympy.utilities.pytest import raises
 
 x = Symbol('x')
@@ -1125,6 +1124,36 @@ def test_print_Lambda():
 def test_print_conjugate():
     assert mpp.doprint(conjugate(x)) == '<menclose notation="top"><mi>x</mi></menclose>'
     assert mpp.doprint(conjugate(x + 1)) == '<mrow><menclose notation="top"><mi>x</mi></menclose><mo>+</mo><mn>1</mn></mrow>'
+
+
+def test_mathml_builtins():
+    assert mpp.doprint(None) == '<mi>None</mi>'
+    assert mpp.doprint(true) == '<mi>True</mi>'
+    assert mpp.doprint(false) == '<mi>False</mi>'
+
+
+def test_mathml_Range():
+    assert mpp.doprint(Range(1, 51)) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mi>&#8230;</mi><mn>50</mn></mfenced>'
+    assert mpp.doprint(Range(1, 4)) == '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
+    assert mpp.doprint(Range(0, 3, 1)) == '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mn>2</mn></mfenced>'
+    assert mpp.doprint(Range(0, 30, 1)) == '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mi>&#8230;</mi><mn>29</mn></mfenced>'
+    assert mpp.doprint(Range(30, 1, -1)) == '<mfenced close="}" open="{"><mn>30</mn><mn>29</mn><mi>&#8230;</mi><mn>2</mn></mfenced>'
+    assert mpp.doprint(Range(0, oo, 2)) == '<mfenced close="}" open="{"><mn>0</mn><mn>2</mn><mi>&#8230;</mi><mi>&#x221E;</mi></mfenced>'
+    assert mpp.doprint(Range(oo, -2, -2)) == '<mfenced close="}" open="{"><mi>&#x221E;</mi><mi>&#8230;</mi><mn>2</mn><mn>0</mn></mfenced>'
+    assert mpp.doprint(Range(-2, -oo, -1)) == '<mfenced close="}" open="{"><mn>-2</mn><mn>-3</mn><mi>&#8230;</mi><mrow><mo>-</mo><mi>&#x221E;</mi></mrow></mfenced>'
+
+
+def test_print_exp():
+    assert mpp.doprint(exp(x)) == '<msup><mi>&ExponentialE;</mi><mi>x</mi></msup>'
+    assert mpp.doprint(exp(1) + exp(2)) == '<mrow><mi>&ExponentialE;</mi><mo>+</mo><msup><mi>&ExponentialE;</mi><mn>2</mn></msup></mrow>'
+
+
+def test_print_MinMax():
+    assert mpp.doprint(Min(x, y)) == '<mrow><mo>min</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Min(x, 2, x**3)) == '<mrow><mo>min</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
+    assert mpp.doprint(Max(x, y)) == '<mrow><mo>max</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Max(x, 2, x**3)) == '<mrow><mo>max</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
 
 
 def test_print_matrix_symbol():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,19 +1,21 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
-    pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, S, \
-    MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
+    pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, \
+    S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
     Lambda, IndexedBase, symbols
 from sympy.core.containers import Tuple
-from sympy.functions.combinatorial.factorials import factorial, factorial2, binomial
+from sympy.functions.combinatorial.factorials import factorial, factorial2, \
+    binomial
 from sympy.functions.elementary.complexes import re, im, Abs, conjugate
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.zeta_functions import polylog, lerchphi
 from sympy.logic.boolalg import And, Or, Implies, Equivalent, Xor, Not
 from sympy.matrices.expressions.determinant import Determinant
-from sympy.printing.mathml import mathml, MathMLContentPrinter, MathMLPresentationPrinter, \
-    MathMLPrinter
-from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, SymmetricDifference
+from sympy.printing.mathml import mathml, MathMLContentPrinter, \
+    MathMLPresentationPrinter, MathMLPrinter
+from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
+    SymmetricDifference
 from sympy.stats.rv import RandomSymbol
 from sympy.sets.sets import Interval
 from sympy.utilities.pytest import raises
@@ -22,6 +24,7 @@ x = Symbol('x')
 y = Symbol('y')
 mp = MathMLContentPrinter()
 mpp = MathMLPresentationPrinter()
+
 
 def test_mathml_printer():
     m = MathMLPrinter()
@@ -109,6 +112,7 @@ def test_content_mathml_integrals():
     assert mml_1.childNodes[3].nodeName == 'uplimit'
     assert mml_1.childNodes[4].toxml() == mp._print(integrand).toxml()
 
+
 def test_content_mathml_matrices():
     A = Matrix([1, 2, 3])
     B = Matrix([[0, 5, 4], [2, 3, 1], [9, 7, 9]])
@@ -144,6 +148,7 @@ def test_content_mathml_matrices():
     assert mll_2.childNodes[2].childNodes[1].childNodes[0].nodeValue == '7'
     assert mll_2.childNodes[2].childNodes[2].nodeName == 'cn'
     assert mll_2.childNodes[2].childNodes[2].childNodes[0].nodeValue == '9'
+
 
 def test_content_mathml_sums():
     summand = x
@@ -404,7 +409,7 @@ def test_content_mathml_greek():
     assert mp.doprint(Symbol('omicron')) == '<ci>&#959;</ci>'
     assert mp.doprint(Symbol('pi')) == '<ci>&#960;</ci>'
     assert mp.doprint(Symbol('rho')) == '<ci>&#961;</ci>'
-    assert mp.doprint(Symbol('varsigma')) == '<ci>&#962;</ci>', mp.doprint(Symbol('varsigma'))
+    assert mp.doprint(Symbol('varsigma')) == '<ci>&#962;</ci>'
     assert mp.doprint(Symbol('sigma')) == '<ci>&#963;</ci>'
     assert mp.doprint(Symbol('tau')) == '<ci>&#964;</ci>'
     assert mp.doprint(Symbol('upsilon')) == '<ci>&#965;</ci>'
@@ -472,7 +477,11 @@ def test_content_settings():
 def test_presentation_printmethod():
     assert mpp.doprint(1 + x) == '<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>'
     assert mpp.doprint(x**2) == '<msup><mi>x</mi><mn>2</mn></msup>'
-    assert mpp.doprint(2*x) == '<mrow><mn>2</mn><mo>&InvisibleTimes;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(x**-1) == '<mfrac><mn>1</mn><mi>x</mi></mfrac>'
+    assert mpp.doprint(x**-2) == \
+        '<mfrac><mn>1</mn><msup><mi>x</mi><mn>2</mn></msup></mfrac>'
+    assert mpp.doprint(2*x) == \
+        '<mrow><mn>2</mn><mo>&InvisibleTimes;</mo><mi>x</mi></mrow>'
 
 
 def test_presentation_mathml_core():
@@ -538,8 +547,10 @@ def test_print_derivative():
     f = Function('f')
     z = Symbol('z')
     d = Derivative(f(x, y, z), x, z, x, z, z, y)
-    assert mathml(d) == r'<apply><partialdiff/><bvar><ci>y</ci><ci>z</ci><degree><cn>2</cn></degree><ci>x</ci><ci>z</ci><ci>x</ci></bvar><apply><f/><ci>x</ci><ci>y</ci><ci>z</ci></apply></apply>'
-    assert mathml(d, printer='presentation') == r'<mrow><mfrac><mrow><msup><mo>&#x2202;</mo><mn>6</mn></msup></mrow><mrow><mo>&#x2202;</mo><mi>y</mi><msup><mo>&#x2202;</mo><mn>2</mn></msup><mi>z</mi><mo>&#x2202;</mo><mi>x</mi><mo>&#x2202;</mo><mi>z</mi><mo>&#x2202;</mo><mi>x</mi></mrow></mfrac><mrow><mi>f</mi><mfenced><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow></mrow>'
+    assert mathml(d) == \
+        '<apply><partialdiff/><bvar><ci>y</ci><ci>z</ci><degree><cn>2</cn></degree><ci>x</ci><ci>z</ci><ci>x</ci></bvar><apply><f/><ci>x</ci><ci>y</ci><ci>z</ci></apply></apply>'
+    assert mathml(d, printer='presentation') == \
+        '<mrow><mfrac><mrow><msup><mo>&#x2202;</mo><mn>6</mn></msup></mrow><mrow><mo>&#x2202;</mo><mi>y</mi><msup><mo>&#x2202;</mo><mn>2</mn></msup><mi>z</mi><mo>&#x2202;</mo><mi>x</mi><mo>&#x2202;</mo><mi>z</mi><mo>&#x2202;</mo><mi>x</mi></mrow></mfrac><mrow><mi>f</mi><mfenced><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow></mrow>'
 
 
 def test_presentation_mathml_limits():
@@ -560,14 +571,21 @@ def test_presentation_mathml_limits():
 
 
 def test_presentation_mathml_integrals():
-    assert mpp.doprint(Integral(x, (x, 0, 1))) == '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(log(x), x)) == '<mrow><mo>&#x222B;</mo><mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x*y, x, y)) == '<mrow><mo>&#x222C;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, (x, 0, 1))) == \
+        '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(log(x), x)) == \
+        '<mrow><mo>&#x222B;</mo><mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y, x, y)) == \
+        '<mrow><mo>&#x222C;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
     z, w = symbols('z w')
-    assert mpp.doprint(Integral(x*y*z, x, y, z)) == '<mrow><mo>&#x222D;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x*y*z*w, x, y, z, w)) == '<mrow><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mrow><mi>w</mi><mo>&InvisibleTimes;</mo><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>w</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x, x, y, (z, 0, 1))) == '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mo>&#x222B;</mo><mo>&#x222B;</mo><mi>x</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x, (x, 0))) == '<mrow><msup><mo>&#x222B;</mo><mn>0</mn></msup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y*z, x, y, z)) == \
+        '<mrow><mo>&#x222D;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y*z*w, x, y, z, w)) == \
+        '<mrow><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mrow><mi>w</mi><mo>&InvisibleTimes;</mo><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>w</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, x, y, (z, 0, 1))) == \
+        '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mo>&#x222B;</mo><mo>&#x222B;</mo><mi>x</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, (x, 0))) == \
+        '<mrow><msup><mo>&#x222B;</mo><mn>0</mn></msup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
 
 
 def test_presentation_mathml_matrices():
@@ -854,7 +872,7 @@ def test_presentation_mathml_greek():
     assert mpp.doprint(Symbol('omicron')) == '<mi>&#959;</mi>'
     assert mpp.doprint(Symbol('pi')) == '<mi>&#960;</mi>'
     assert mpp.doprint(Symbol('rho')) == '<mi>&#961;</mi>'
-    assert mpp.doprint(Symbol('varsigma')) == '<mi>&#962;</mi>', mp.doprint(Symbol('varsigma'))
+    assert mpp.doprint(Symbol('varsigma')) == '<mi>&#962;</mi>'
     assert mpp.doprint(Symbol('sigma')) == '<mi>&#963;</mi>'
     assert mpp.doprint(Symbol('tau')) == '<mi>&#964;</mi>'
     assert mpp.doprint(Symbol('upsilon')) == '<mi>&#965;</mi>'
@@ -916,49 +934,69 @@ def test_presentation_mathml_order():
 
 def test_print_intervals():
     a = Symbol('a', real=True)
-    assert mpp.doprint(Interval(0, a)) == '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, False, False)) == '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, True, False)) == '<mrow><mfenced close="]" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, False, True)) == '<mrow><mfenced close=")" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, True, True)) == '<mrow><mfenced close=")" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a)) == \
+        '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, False, False)) == \
+        '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, True, False)) == \
+        '<mrow><mfenced close="]" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, False, True)) == \
+        '<mrow><mfenced close=")" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, True, True)) == \
+        '<mrow><mfenced close=")" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
 
 
 def test_print_tuples():
     a = Symbol('a')
-    assert mpp.doprint(Tuple(0,)) == '<mrow><mfenced><mn>0</mn></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, a)) == '<mrow><mfenced><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, a, a)) == '<mrow><mfenced><mn>0</mn><mi>a</mi><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, 1, 2, 3, 4)) == '<mrow><mfenced><mn>0</mn><mn>1</mn><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, 1, Tuple(2, 3, 4))) == '<mrow><mfenced><mn>0</mn><mn>1</mn><mrow><mfenced><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0,)) == \
+        '<mrow><mfenced><mn>0</mn></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, a)) == \
+        '<mrow><mfenced><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, a, a)) == \
+        '<mrow><mfenced><mn>0</mn><mi>a</mi><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, 1, 2, 3, 4)) == \
+        '<mrow><mfenced><mn>0</mn><mn>1</mn><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, 1, Tuple(2, 3, 4))) == \
+        '<mrow><mfenced><mn>0</mn><mn>1</mn><mrow><mfenced><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow></mfenced></mrow>'
 
 
 def test_print_re_im():
     x = Symbol('x')
-    assert mpp.doprint(re(x)) == '<mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mpp.doprint(im(x)) == '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mpp.doprint(re(x + 1)) == '<mrow><mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow><mo>+</mo><mn>1</mn></mrow>'
-    assert mpp.doprint(im(x + 1)) == '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(re(x)) == \
+        '<mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(im(x)) == \
+        '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(re(x + 1)) == \
+        '<mrow><mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow><mo>+</mo><mn>1</mn></mrow>'
+    assert mpp.doprint(im(x + 1)) == \
+        '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
 
 
 def test_print_Abs():
     x = Symbol('x')
-    assert mpp.doprint(Abs(x)) == '<mrow><mfenced close="|" open="|"><mi>x</mi></mfenced></mrow>'
-    assert mpp.doprint(Abs(x + 1)) == '<mrow><mfenced close="|" open="|"><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced></mrow>'
+    assert mpp.doprint(Abs(x)) == \
+        '<mrow><mfenced close="|" open="|"><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(Abs(x + 1)) == \
+        '<mrow><mfenced close="|" open="|"><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced></mrow>'
 
 
 def test_print_Determinant():
-    assert mpp.doprint(Determinant(Matrix([[1, 2], [3, 4]]))) == '<mrow><mfenced close="|" open="|"><mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced></mfenced></mrow>'
+    assert mpp.doprint(Determinant(Matrix([[1, 2], [3, 4]]))) == \
+        '<mrow><mfenced close="|" open="|"><mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced></mfenced></mrow>'
 
 
 def test_presentation_settings():
-    raises(TypeError, lambda: mathml(Symbol("x"), printer='presentation',method="garbage"))
+    raises(TypeError, lambda: mathml(Symbol("x"), printer='presentation',
+                                     method="garbage"))
+
 
 def test_toprettyxml_hooking():
-    # test that the patch doesn't influence the behavior of the standard library
+    # test that the patch doesn't influence the behavior of the standard
+    # library
     import xml.dom.minidom
     doc1 = xml.dom.minidom.parseString(
         "<apply><plus/><ci>x</ci><cn>1</cn></apply>")
-    doc2 =  xml.dom.minidom.parseString(
+    doc2 = xml.dom.minidom.parseString(
         "<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>")
     prettyxml_old1 = doc1.toprettyxml()
     prettyxml_old2 = doc2.toprettyxml()
@@ -976,152 +1014,212 @@ def test_print_domains():
     assert mpp.doprint(Complexes) == '<mi mathvariant="normal">&#x2102;</mi>'
     assert mpp.doprint(Integers) == '<mi mathvariant="normal">&#x2124;</mi>'
     assert mpp.doprint(Naturals) == '<mi mathvariant="normal">&#x2115;</mi>'
-    assert mpp.doprint(Naturals0) == '<msub><mi mathvariant="normal">&#x2115;</mi><mn>0</mn></msub>'
+    assert mpp.doprint(Naturals0) == \
+        '<msub><mi mathvariant="normal">&#x2115;</mi><mn>0</mn></msub>'
     assert mpp.doprint(Reals) == '<mi mathvariant="normal">&#x211D;</mi>'
 
 
 def test_print_expression_with_minus():
     assert mpp.doprint(-x) == '<mrow><mo>-</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(-x/y) == '<mrow><mo>-</mo><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow>'
-    assert mpp.doprint(-Rational(1,2)) == '<mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow>'
+    assert mpp.doprint(-x/y) == \
+        '<mrow><mo>-</mo><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow>'
+    assert mpp.doprint(-Rational(1, 2)) == \
+        '<mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow>'
 
 
 def test_print_AssocOp():
     from sympy.core.operations import AssocOp
+
     class TestAssocOp(AssocOp):
         identity = 0
 
     expr = TestAssocOp(1, 2)
-    mpp.doprint(expr) == '<mrow><mi>testassocop</mi><mn>2</mn><mn>1</mn></mrow>'
+    mpp.doprint(expr) == \
+        '<mrow><mi>testassocop</mi><mn>2</mn><mn>1</mn></mrow>'
 
 
 def test_print_basic():
     expr = Basic(1, 2)
-    assert mpp.doprint(expr) == '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'
+    assert mpp.doprint(expr) == \
+        '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'
     assert mp.doprint(expr) == '<basic><cn>1</cn><cn>2</cn></basic>'
 
 
 def test_mat_delim_print():
     expr = Matrix([[1, 2], [3, 4]])
-    assert mathml(expr, printer='presentation', mat_delim='[') == '<mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
-    assert mathml(expr, printer='presentation', mat_delim='(') == '<mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
-    assert mathml(expr, printer='presentation', mat_delim='') == '<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>'
+    assert mathml(expr, printer='presentation', mat_delim='[') == \
+        '<mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
+    assert mathml(expr, printer='presentation', mat_delim='(') == \
+        '<mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
+    assert mathml(expr, printer='presentation', mat_delim='') == \
+        '<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>'
 
 
 def test_ln_notation_print():
     expr = log(x)
-    assert mathml(expr, printer='presentation') == '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mathml(expr, printer='presentation', ln_notation=False) == '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mathml(expr, printer='presentation', ln_notation=True) == '<mrow><mi>ln</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation', ln_notation=False) == \
+        '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation', ln_notation=True) == \
+        '<mrow><mi>ln</mi><mfenced><mi>x</mi></mfenced></mrow>'
 
 
 def test_mul_symbol_print():
     expr = x * y
-    assert mathml(expr, printer='presentation') == '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol=None) == '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol='dot') == '<mrow><mi>x</mi><mo>&#xB7;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol='ldot') == '<mrow><mi>x</mi><mo>&#x2024;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol='times') == '<mrow><mi>x</mi><mo>&#xD7;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol=None) == \
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol='dot') == \
+        '<mrow><mi>x</mi><mo>&#xB7;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol='ldot') == \
+        '<mrow><mi>x</mi><mo>&#x2024;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol='times') == \
+        '<mrow><mi>x</mi><mo>&#xD7;</mo><mi>y</mi></mrow>'
 
 
 def test_print_lerchphi():
-    assert mpp.doprint(lerchphi(1, 2, 3)) == '<mrow><mi>&#x3A6;</mi><mfenced><mn>1</mn><mn>2</mn><mn>3</mn></mfenced></mrow>'
+    assert mpp.doprint(lerchphi(1, 2, 3)) == \
+        '<mrow><mi>&#x3A6;</mi><mfenced><mn>1</mn><mn>2</mn><mn>3</mn></mfenced></mrow>'
 
 
 def test_print_polylog():
-    assert mp.doprint(polylog(x, y)) == '<apply><polylog/><ci>x</ci><ci>y</ci></apply>'
-    assert mpp.doprint(polylog(x, y)) == '<mrow><msub><mi>Li</mi><mi>x</mi></msub><mfenced><mi>y</mi></mfenced></mrow>'
+    assert mp.doprint(polylog(x, y)) == \
+        '<apply><polylog/><ci>x</ci><ci>y</ci></apply>'
+    assert mpp.doprint(polylog(x, y)) == \
+        '<mrow><msub><mi>Li</mi><mi>x</mi></msub><mfenced><mi>y</mi></mfenced></mrow>'
 
 
 def test_print_set_frozenset():
     f = frozenset({1, 5, 3})
-    assert mpp.doprint(f) == '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mn>5</mn></mfenced>'
+    assert mpp.doprint(f) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mn>5</mn></mfenced>'
     s = set({1, 2, 3})
-    assert mpp.doprint(s) == '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
+    assert mpp.doprint(s) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
 
 
 def test_print_FiniteSet():
     f1 = FiniteSet(x, 1, 3)
-    assert mpp.doprint(f1) == '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced>'
+    assert mpp.doprint(f1) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced>'
 
 
 def test_print_SetOp():
     f1 = FiniteSet(x, 1, 3)
     f2 = FiniteSet(y, 2, 4)
 
-    assert mpp.doprint(Union(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Intersection(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2229;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Complement(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(SymmetricDifference(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Union(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Intersection(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2229;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Complement(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(SymmetricDifference(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
 
 
 def test_print_logic():
-    assert mpp.doprint(And(x, y)) == '<mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Or(x, y)) == '<mrow><mi>x</mi><mo>&#x2228;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Xor(x, y)) == '<mrow><mi>x</mi><mo>&#x22BB;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Implies(x, y)) == '<mrow><mi>x</mi><mo>&#x21D2;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Equivalent(x, y)) == '<mrow><mi>x</mi><mo>&#x21D4;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(And(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Or(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x2228;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Xor(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x22BB;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Implies(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x21D2;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Equivalent(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x21D4;</mo><mi>y</mi></mrow>'
 
-    assert mpp.doprint(And(Eq(x, y), x > 4)) == '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
-    assert mpp.doprint(And(Eq(x, 3), y < 3, x > y + 1)) == '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2227;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow>'
-    assert mpp.doprint(Or(Eq(x, y), x > 4)) == '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2228;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
-    assert mpp.doprint(And(Eq(x, 3), Or(y < 3, x > y + 1))) == '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mfenced><mrow><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2228;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow></mfenced></mrow>'
+    assert mpp.doprint(And(Eq(x, y), x > 4)) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
+    assert mpp.doprint(And(Eq(x, 3), y < 3, x > y + 1)) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2227;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow>'
+    assert mpp.doprint(Or(Eq(x, y), x > 4)) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2228;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
+    assert mpp.doprint(And(Eq(x, 3), Or(y < 3, x > y + 1))) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mfenced><mrow><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2228;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow></mfenced></mrow>'
 
     assert mpp.doprint(Not(x)) == '<mrow><mo>&#xAC;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Not(And(x, y))) == '<mrow><mo>&#xAC;</mo><mfenced><mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow></mfenced></mrow>'
+    assert mpp.doprint(Not(And(x, y))) == \
+        '<mrow><mo>&#xAC;</mo><mfenced><mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow></mfenced></mrow>'
+
 
 def test_root_notation_print():
-    assert mathml(x**(S(1)/3), printer='presentation') == '<mroot><mi>x</mi><mn>3</mn></mroot>'
-    assert mathml(x**(S(1)/3), printer='presentation', root_notation=False) == '<msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup>'
-    assert mathml(x**(S(1)/3), printer='content') == '<apply><root/><degree><ci>3</ci></degree><ci>x</ci></apply>'
-    assert mathml(x**(S(1)/3), printer='content', root_notation=False) == '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'
-    assert mathml(x**(-S(1)/3), printer='presentation') == '<mfrac><mn>1</mn><mroot><mi>x</mi><mn>3</mn></mroot></mfrac>'
-    assert mathml(x**(-S(1)/3), printer='presentation', root_notation=False) == '<mfrac><mn>1</mn><msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup></mfrac>'
+    assert mathml(x**(S(1)/3), printer='presentation') == \
+        '<mroot><mi>x</mi><mn>3</mn></mroot>'
+    assert mathml(x**(S(1)/3), printer='presentation', root_notation=False) ==\
+        '<msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup>'
+    assert mathml(x**(S(1)/3), printer='content') == \
+        '<apply><root/><degree><ci>3</ci></degree><ci>x</ci></apply>'
+    assert mathml(x**(S(1)/3), printer='content', root_notation=False) == \
+        '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'
+    assert mathml(x**(-S(1)/3), printer='presentation') == \
+        '<mfrac><mn>1</mn><mroot><mi>x</mi><mn>3</mn></mroot></mfrac>'
+    assert mathml(x**(-S(1)/3), printer='presentation', root_notation=False) \
+        == '<mfrac><mn>1</mn><msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup></mfrac>'
 
 
 def test_fold_frac_powers_print():
     expr = x ** Rational(5, 2)
-    assert mathml(expr, printer='presentation') == '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
-    assert mathml(expr, printer='presentation', fold_frac_powers=True) == '<msup><mi>x</mi><mfrac bevelled="true"><mn>5</mn><mn>2</mn></mfrac></msup>'
-    assert mathml(expr, printer='presentation', fold_frac_powers=False) == '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation') == \
+        '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation', fold_frac_powers=True) == \
+        '<msup><mi>x</mi><mfrac bevelled="true"><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation', fold_frac_powers=False) == \
+        '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
 
 
 def test_fold_short_frac_print():
     expr = Rational(2, 5)
-    assert mathml(expr, printer='presentation') == '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
-    assert mathml(expr, printer='presentation', fold_short_frac=True) == '<mfrac bevelled="true"><mn>2</mn><mn>5</mn></mfrac>'
-    assert mathml(expr, printer='presentation', fold_short_frac=False) == '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation') == \
+        '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=True) == \
+        '<mfrac bevelled="true"><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=False) == \
+        '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
 
 
 def test_print_factorials():
     assert mpp.doprint(factorial(x)) == '<mrow><mi>x</mi><mo>!</mo></mrow>'
-    assert mpp.doprint(factorial(x + 1)) == '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!</mo></mrow>'
+    assert mpp.doprint(factorial(x + 1)) == \
+        '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!</mo></mrow>'
     assert mpp.doprint(factorial2(x)) == '<mrow><mi>x</mi><mo>!!</mo></mrow>'
-    assert mpp.doprint(factorial2(x + 1)) == '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!!</mo></mrow>'
-    assert mpp.doprint(binomial(x, y)) == '<mfenced><mfrac linethickness="0"><mi>x</mi><mi>y</mi></mfrac></mfenced>'
-    assert mpp.doprint(binomial(4, x + y)) == '<mfenced><mfrac linethickness="0"><mn>4</mn><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mfrac></mfenced>'
+    assert mpp.doprint(factorial2(x + 1)) == \
+        '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!!</mo></mrow>'
+    assert mpp.doprint(binomial(x, y)) == \
+        '<mfenced><mfrac linethickness="0"><mi>x</mi><mi>y</mi></mfrac></mfenced>'
+    assert mpp.doprint(binomial(4, x + y)) == \
+        '<mfenced><mfrac linethickness="0"><mn>4</mn><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mfrac></mfenced>'
 
 
 def test_print_floor():
     expr = floor(x)
-    assert mathml(expr, printer='presentation') == '<mrow><mfenced close="&#8971;" open="&#8970;"><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mfenced close="&#8971;" open="&#8970;"><mi>x</mi></mfenced></mrow>'
 
 
 def test_print_ceiling():
     expr = ceiling(x)
-    assert mathml(expr, printer='presentation') == '<mrow><mfenced close="&#8969;" open="&#8968;"><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mfenced close="&#8969;" open="&#8968;"><mi>x</mi></mfenced></mrow>'
 
 
 def test_print_Lambda():
     expr = Lambda(x, x+1)
-    assert mathml(expr, printer='presentation') == '<mfenced><mrow><mi>x</mi><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mrow></mfenced>'
+    assert mathml(expr, printer='presentation') == \
+        '<mfenced><mrow><mi>x</mi><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mrow></mfenced>'
     expr = Lambda((x, y), x + y)
-    assert mathml(expr, printer='presentation') == '<mfenced><mrow><mrow><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mrow></mfenced>'
+    assert mathml(expr, printer='presentation') == \
+        '<mfenced><mrow><mrow><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mrow></mfenced>'
 
 
 def test_print_conjugate():
-    assert mpp.doprint(conjugate(x)) == '<menclose notation="top"><mi>x</mi></menclose>'
-    assert mpp.doprint(conjugate(x + 1)) == '<mrow><menclose notation="top"><mi>x</mi></menclose><mo>+</mo><mn>1</mn></mrow>'
+    assert mpp.doprint(conjugate(x)) == \
+        '<menclose notation="top"><mi>x</mi></menclose>'
+    assert mpp.doprint(conjugate(x + 1)) == \
+        '<mrow><menclose notation="top"><mi>x</mi></menclose><mo>+</mo><mn>1</mn></mrow>'
 
 
 def test_mathml_builtins():
@@ -1133,33 +1231,48 @@ def test_mathml_builtins():
 def test_mathml_Range():
     assert mpp.doprint(Range(1, 51)) == \
         '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mi>&#8230;</mi><mn>50</mn></mfenced>'
-    assert mpp.doprint(Range(1, 4)) == '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
-    assert mpp.doprint(Range(0, 3, 1)) == '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mn>2</mn></mfenced>'
-    assert mpp.doprint(Range(0, 30, 1)) == '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mi>&#8230;</mi><mn>29</mn></mfenced>'
-    assert mpp.doprint(Range(30, 1, -1)) == '<mfenced close="}" open="{"><mn>30</mn><mn>29</mn><mi>&#8230;</mi><mn>2</mn></mfenced>'
-    assert mpp.doprint(Range(0, oo, 2)) == '<mfenced close="}" open="{"><mn>0</mn><mn>2</mn><mi>&#8230;</mi><mi>&#x221E;</mi></mfenced>'
-    assert mpp.doprint(Range(oo, -2, -2)) == '<mfenced close="}" open="{"><mi>&#x221E;</mi><mi>&#8230;</mi><mn>2</mn><mn>0</mn></mfenced>'
-    assert mpp.doprint(Range(-2, -oo, -1)) == '<mfenced close="}" open="{"><mn>-2</mn><mn>-3</mn><mi>&#8230;</mi><mrow><mo>-</mo><mi>&#x221E;</mi></mrow></mfenced>'
+    assert mpp.doprint(Range(1, 4)) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
+    assert mpp.doprint(Range(0, 3, 1)) == \
+        '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mn>2</mn></mfenced>'
+    assert mpp.doprint(Range(0, 30, 1)) == \
+        '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mi>&#8230;</mi><mn>29</mn></mfenced>'
+    assert mpp.doprint(Range(30, 1, -1)) == \
+        '<mfenced close="}" open="{"><mn>30</mn><mn>29</mn><mi>&#8230;</mi><mn>2</mn></mfenced>'
+    assert mpp.doprint(Range(0, oo, 2)) == \
+        '<mfenced close="}" open="{"><mn>0</mn><mn>2</mn><mi>&#8230;</mi><mi>&#x221E;</mi></mfenced>'
+    assert mpp.doprint(Range(oo, -2, -2)) == \
+        '<mfenced close="}" open="{"><mi>&#x221E;</mi><mi>&#8230;</mi><mn>2</mn><mn>0</mn></mfenced>'
+    assert mpp.doprint(Range(-2, -oo, -1)) == \
+        '<mfenced close="}" open="{"><mn>-2</mn><mn>-3</mn><mi>&#8230;</mi><mrow><mo>-</mo><mi>&#x221E;</mi></mrow></mfenced>'
 
 
 def test_print_exp():
-    assert mpp.doprint(exp(x)) == '<msup><mi>&ExponentialE;</mi><mi>x</mi></msup>'
-    assert mpp.doprint(exp(1) + exp(2)) == '<mrow><mi>&ExponentialE;</mi><mo>+</mo><msup><mi>&ExponentialE;</mi><mn>2</mn></msup></mrow>'
+    assert mpp.doprint(exp(x)) == \
+        '<msup><mi>&ExponentialE;</mi><mi>x</mi></msup>'
+    assert mpp.doprint(exp(1) + exp(2)) == \
+        '<mrow><mi>&ExponentialE;</mi><mo>+</mo><msup><mi>&ExponentialE;</mi><mn>2</mn></msup></mrow>'
 
 
 def test_print_MinMax():
-    assert mpp.doprint(Min(x, y)) == '<mrow><mo>min</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Min(x, 2, x**3)) == '<mrow><mo>min</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
-    assert mpp.doprint(Max(x, y)) == '<mrow><mo>max</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Max(x, 2, x**3)) == '<mrow><mo>max</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
+    assert mpp.doprint(Min(x, y)) == \
+        '<mrow><mo>min</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Min(x, 2, x**3)) == \
+        '<mrow><mo>min</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
+    assert mpp.doprint(Max(x, y)) == \
+        '<mrow><mo>max</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Max(x, 2, x**3)) == \
+        '<mrow><mo>max</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
 
 
 def test_print_matrix_symbol():
     A = MatrixSymbol('A', 1, 2)
     assert mpp.doprint(A) == '<mi>A</mi>'
     assert mp.doprint(A) == '<ci>A</ci>'
-    assert mathml(A, printer='presentation', mat_symbol_style="bold" )== '<mi mathvariant="bold">A</mi>'
-    assert mathml(A, mat_symbol_style="bold" )== '<ci>A</ci>' # No effect in content printer
+    assert mathml(A, printer='presentation', mat_symbol_style="bold") == \
+        '<mi mathvariant="bold">A</mi>'
+    # No effect in content printer
+    assert mathml(A, mat_symbol_style="bold") == '<ci>A</ci>'
 
 
 def test_print_random_symbol():
@@ -1169,14 +1282,20 @@ def test_print_random_symbol():
 
 
 def test_print_IndexedBase():
-    a,b,c,d,e = symbols('a b c d e')
-    assert mathml(IndexedBase(a)[b],printer='presentation') == '<msub><mi>a</mi><mi>b</mi></msub>'
-    assert mathml(IndexedBase(a)[b,c,d],printer = 'presentation') == '<msub><mi>a</mi><mfenced><mi>b</mi><mi>c</mi><mi>d</mi></mfenced></msub>'
-    assert mathml(IndexedBase(a)[b]*IndexedBase(c)[d]*IndexedBase(e),printer = 'presentation') == '<mrow><msub><mi>a</mi><mi>b</mi></msub><mo>&InvisibleTimes;</mo><msub><mi>c</mi><mi>d</mi></msub><mo>&InvisibleTimes;</mo><mi>e</mi></mrow>'
+    a, b, c, d, e = symbols('a b c d e')
+    assert mathml(IndexedBase(a)[b], printer='presentation') == \
+        '<msub><mi>a</mi><mi>b</mi></msub>'
+    assert mathml(IndexedBase(a)[b, c, d], printer='presentation') == \
+        '<msub><mi>a</mi><mfenced><mi>b</mi><mi>c</mi><mi>d</mi></mfenced></msub>'
+    assert mathml(IndexedBase(a)[b]*IndexedBase(c)[d]*IndexedBase(e),
+                  printer='presentation') == \
+                  '<mrow><msub><mi>a</mi><mi>b</mi></msub><mo>&InvisibleTimes;</mo><msub><mi>c</mi><mi>d</mi></msub><mo>&InvisibleTimes;</mo><mi>e</mi></mrow>'
 
 
 def test_print_Indexed():
-    a,b,c = symbols('a b c')
-    assert mathml(IndexedBase(a),printer = 'presentation') == '<mi>a</mi>'
-    assert mathml(IndexedBase(a/b),printer = 'presentation') == '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
-    assert mathml(IndexedBase((a,b)),printer = 'presentation') == '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'
+    a, b, c = symbols('a b c')
+    assert mathml(IndexedBase(a), printer='presentation') == '<mi>a</mi>'
+    assert mathml(IndexedBase(a/b), printer='presentation') == \
+        '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
+    assert mathml(IndexedBase((a, b)), printer='presentation') == \
+        '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -560,16 +560,14 @@ def test_presentation_mathml_limits():
 
 
 def test_presentation_mathml_integrals():
-    integrand = x
-    mml_1 = mpp._print(Integral(integrand, (x, 0, 1)))
-    assert mml_1.childNodes[0].nodeName == 'msubsup'
-    assert len(mml_1.childNodes[0].childNodes) == 3
-    assert mml_1.childNodes[0].childNodes[0
-        ].childNodes[0].nodeValue == '&int;'
-    assert mml_1.childNodes[0].childNodes[1
-        ].childNodes[0].nodeValue == '0'
-    assert mml_1.childNodes[0].childNodes[2
-        ].childNodes[0].nodeValue == '1'
+    assert mpp.doprint(Integral(x, (x, 0, 1))) == '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(log(x), x)) == '<mrow><mo>&#x222B;</mo><mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y, x, y)) == '<mrow><mo>&#x222C;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    z, w = symbols('z w')
+    assert mpp.doprint(Integral(x*y*z, x, y, z)) == '<mrow><mo>&#x222D;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y*z*w, x, y, z, w)) == '<mrow><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mrow><mi>w</mi><mo>&InvisibleTimes;</mo><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>w</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, x, y, (z, 0, 1))) == '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mo>&#x222B;</mo><mo>&#x222B;</mo><mi>x</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, (x, 0))) == '<mrow><msup><mo>&#x222B;</mo><mn>0</mn></msup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
 
 
 def test_presentation_mathml_matrices():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,7 +1,7 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, S, \
-    MatrixSymbol, Function, Derivative, log, Lambda
+    MatrixSymbol, Function, Derivative, log, Lambda, IndexedBase, symbols
 from sympy.core.containers import Tuple
 from sympy.functions.elementary.complexes import re, im, Abs, conjugate
 from sympy.functions.elementary.integers import floor, ceiling
@@ -1139,3 +1139,17 @@ def test_print_random_symbol():
     R = RandomSymbol(Symbol('R'))
     assert mpp.doprint(R) == '<mi>R</mi>'
     assert mp.doprint(R) == '<ci>R</ci>'
+
+
+def test_print_IndexedBase():
+    a,b,c,d,e = symbols('a b c d e')
+    assert mathml(IndexedBase(a)[b],printer='presentation') == '<msub><mi>a</mi><mi>b</mi></msub>'
+    assert mathml(IndexedBase(a)[b,c,d],printer = 'presentation') == '<msub><mi>a</mi><mfenced><mi>b</mi><mi>c</mi><mi>d</mi></mfenced></msub>'
+    assert mathml(IndexedBase(a)[b]*IndexedBase(c)[d]*IndexedBase(e),printer = 'presentation') == '<mrow><msub><mi>a</mi><mi>b</mi></msub><mo>&InvisibleTimes;</mo><msub><mi>c</mi><mi>d</mi></msub><mo>&InvisibleTimes;</mo><mi>e</mi></mrow>'
+
+
+def test_print_Indexed():
+    a,b,c = symbols('a b c')
+    assert mathml(IndexedBase(a),printer = 'presentation') == '<mi>a</mi>'
+    assert mathml(IndexedBase(a/b),printer = 'presentation') == '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
+    assert mathml(IndexedBase((a,b)),printer = 'presentation') == '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -96,30 +96,28 @@ def finite_check(f, x, L):
     def check_fx(exprs, x):
         return x not in exprs.free_symbols
 
-    def check_sincos(expr, x, L):
-        if type(expr) == sin or type(expr) == cos:
-            sincos_args = expr.args[0]
+    def check_sincos(_expr, x, L):
+        if isinstance(_expr, (sin, cos)):
+            sincos_args = _expr.args[0]
 
             if sincos_args.match(a*(pi/L)*x + b) is not None:
                 return True
             else:
                 return False
 
-    expr = sincos_to_sum(TR2(TR1(f)))
-    res_expr = S.Zero
-    add_coeff = expr.as_coeff_add()
-    res_expr += add_coeff[0]
+    _expr = sincos_to_sum(TR2(TR1(f)))
+    add_coeff = _expr.as_coeff_add()
 
     a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
-    b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
+    b = Wild('b', properties=[lambda k: x not in k.free_symbols, ])
 
     for s in add_coeff[1]:
         mul_coeffs = s.as_coeff_mul()[1]
         for t in mul_coeffs:
             if not (check_fx(t, x) or check_sincos(t, x, L)):
                 return False, f
-        res_expr += TR10(s)
-    return True, res_expr.collect([sin(a*(pi/L)*x), cos(a*(pi/L)*x)])
+
+    return True, _expr
 
 
 class FourierSeries(SeriesBase):
@@ -179,6 +177,10 @@ class FourierSeries(SeriesBase):
     @property
     def length(self):
         return oo
+
+    @property
+    def L(self):
+        return abs(self.period[1] - self.period[0]) / 2
 
     def _eval_subs(self, old, new):
         x = self.x
@@ -440,16 +442,145 @@ class FourierSeries(SeriesBase):
         return self.__add__(-other)
 
 
-class FiniteFourierSeries(Basic):
-    def __new__(cls, *args):
-        obj = Basic.__new__(cls, *args)
-        return obj
+class FiniteFourierSeries(FourierSeries):
+    r"""Represents Finite Fourier sine/cosine series.
 
-    def truncate(self, n=3):
-        return Add(*self._args)
+    For how to compute Fourier series, see the :func:`fourier_series`
+    docstring.
+
+    Parameters
+    ==========
+    f : Expr
+        Expression for finding fourier_series
+
+    limits : ( x, start, stop)
+        x is the independent variable for the expression f
+        (start, stop) is the period of the fourier series
+
+    exprs: (a0, an, bn) or Expr
+        a0 is the constant term a0 of the fourier series
+        an is a dictionary of coefficients of cos terms
+         an[k] = coefficient of cos(pi*(k/L)*x)
+        bn is a dictionary of coefficients of sin terms
+         bn[k] = coefficient of sin(pi*(k/L)*x)
+
+        or exprs can be an expression to be converted to fourier form
+
+    Methods
+    =======
+    This class is an extension of FourierSeries class.
+    Please refer to sympy.series.fourier.FourierSeries for
+    further information.
+
+    See Also
+    ========
+
+    sympy.series.fourier.FourierSeries
+    sympy.series.fourier.fourier_series
+    """
+
+    def __new__(cls, f, limits, exprs):
+        if not (type(exprs) == tuple and len(exprs) == 3):  # exprs is not of form (a0, an, bn)
+            # Converts the expression to fourier form
+            c, e = exprs.as_coeff_add()
+            rexpr = c + Add(*[TR10(i) for i in e])
+            a0, exp_ls = rexpr.expand(trig=False, power_base=False, power_exp=False, log=False).as_coeff_add()
+
+            x = limits[0]
+            L = abs(limits[2] - limits[1]) / 2
+
+            a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k is not S.Zero, ])
+            b = Wild('b', properties=[lambda k: x not in k.free_symbols, ])
+
+            an = dict()
+            bn = dict()
+
+            # separates the coefficients of sin and cos terms in dictionaries an, and bn
+            for p in exp_ls:
+                t = p.match(b * cos(a * (pi / L) * x))
+                q = p.match(b * sin(a * (pi / L) * x))
+                if t:
+                    an[t[a]] = t[b] + an.get(t[a], S.Zero)
+                elif q:
+                    bn[q[a]] = q[b] + bn.get(q[a], S.Zero)
+                else:
+                    a0 += p
+
+            exprs = (a0, an, bn)
+
+        args = map(sympify, (f, limits, exprs))
+
+        return Expr.__new__(cls, *args)
+
+    @property
+    def interval(self):
+        _length = 1 if self.a0 else 0
+        _length += max(set(self.an.keys()).union(set(self.bn.keys()))) + 1
+        return Interval(0, _length)
+
+    @property
+    def length(self):
+        return self.stop - self.start
+
+    def shiftx(self, s):
+        s, x = sympify(s), self.x
+
+        if x in s.free_symbols:
+            raise ValueError("'%s' should be independent of %s" % (s, x))
+
+        _expr = self.truncate().subs(x, x + s)
+        sfunc = self.function.subs(x, x + s)
+
+        return self.func(sfunc, self.args[1], _expr)
+
+    def scale(self, s):
+        s, x = sympify(s), self.x
+
+        if x in s.free_symbols:
+            raise ValueError("'%s' should be independent of %s" % (s, x))
+
+        _expr = self.truncate() * s
+        sfunc = self.function * s
+
+        return self.func(sfunc, self.args[1], _expr)
+
+    def scalex(self, s):
+        s, x = sympify(s), self.x
+
+        if x in s.free_symbols:
+            raise ValueError("'%s' should be independent of %s" % (s, x))
+
+        _expr = self.truncate().subs(x, x * s)
+        sfunc = self.function.subs(x, x * s)
+
+        return self.func(sfunc, self.args[1], _expr)
+
+    def _eval_term(self, pt):
+        if pt == 0:
+            return self.a0
+
+        _term = self.an.get(pt, S.Zero) * cos(pt * (pi / self.L) * self.x) \
+                + self.bn.get(pt, S.Zero) * sin(pt * (pi / self.L) * self.x)
+        return _term
+
+    def __add__(self, other):
+        if isinstance(other, FourierSeries):
+            return other.__add__(fourier_series(self.function, self.args[1],\
+                                                finite=False))
+        elif isinstance(other, FiniteFourierSeries):
+            if self.period != other.period:
+                raise ValueError("Both the series should have same periods")
+
+            x, y = self.x, other.x
+            function = self.function + other.function.subs(y, x)
+
+            if self.x not in function.free_symbols:
+                return function
+
+            return fourier_series(function, limits=self.args[1])
 
 
-def fourier_series(f, limits=None):
+def fourier_series(f, limits=None, finite=True):
     """Computes Fourier sine/cosine series expansion.
 
     Returns a :class:`FourierSeries` object.
@@ -511,11 +642,11 @@ def fourier_series(f, limits=None):
     if x not in f.free_symbols:
         return f
 
-    L = abs(limits[2] - limits[1])/2
-    is_finite, res_f = finite_check(f, x, L)
-
-    if is_finite:
-        return FiniteFourierSeries(res_f)
+    if finite:
+        L = abs(limits[2] - limits[1]) / 2
+        is_finite, res_f = finite_check(f, x, L)
+        if is_finite:
+            return FiniteFourierSeries(f, limits, res_f)
 
     n = Dummy('n')
     neg_f = f.subs(x, -x)

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -134,15 +134,17 @@ def test_FourierSeries__add__sub():
 
 def test_FourierSeries_finite():
 
-    assert fourier_series(sin(x)).truncate() == sin(x)
+    assert fourier_series(sin(x)).truncate(1) == sin(x)
     # assert type(fourier_series(sin(x)*log(x))).truncate() == FourierSeries
     # assert type(fourier_series(sin(x**2+6))).truncate() == FourierSeries
     assert fourier_series(sin(x)*log(y)*exp(z),(x,pi,-pi)).truncate() == sin(x)*log(y)*exp(z)
-    assert fourier_series(sin(x)**6).truncate() == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
+    assert fourier_series(sin(x)**6).truncate(oo) == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
            + Rational(5, 16)
-    assert fourier_series(sin(4*x+3) + cos(3*x+4)).truncate() ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
+    assert fourier_series(sin(x) ** 6).truncate() == -15 * cos(2 * x) / 32 + 3 * cos(4 * x) / 16 \
+           + Rational(5, 16)
+    assert fourier_series(sin(4*x+3) + cos(3*x+4)).truncate(oo) ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
            + cos(4)*cos(3*x) + sin(3)*cos(4*x)
-    assert fourier_series(sin(x)+cos(x)*tan(x)).truncate() == 2*sin(x)
-    assert fourier_series(cos(pi*x), (x, -1, 1)).truncate() == cos(pi*x)
-    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x, -1, 1)).truncate() == -log(pi*y)*sin(4*pi*x)\
+    assert fourier_series(sin(x)+cos(x)*tan(x)).truncate(oo) == 2*sin(x)
+    assert fourier_series(cos(pi*x), (x, -1, 1)).truncate(oo) == cos(pi*x)
+    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x, -1, 1)).truncate(oo) == -log(pi*y)*sin(4*pi*x)\
            - sin(4)*sin(3*pi*x) + cos(4)*cos(3*pi*x)

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division
 
 from sympy import S
-from sympy.sets.contains import Contains
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
@@ -9,11 +8,10 @@ from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_bool
 from sympy.core.symbol import Symbol, Dummy
 from sympy.logic.boolalg import And, as_Boolean
-from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
-                             FiniteSet)
+from sympy.sets.contains import Contains
+from sympy.sets.sets import Set, EmptySet, Union, FiniteSet
 from sympy.utilities.iterables import sift
 from sympy.utilities.misc import filldedent
-from sympy.multipledispatch import dispatch
 
 
 class ConditionSet(Set):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1,20 +1,15 @@
 from __future__ import print_function, division
 
-from sympy.logic.boolalg import And
-from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, with_metaclass, range, PY3
 from sympy.core.expr import Expr
-from sympy.core.function import Lambda, _coeff_isneg
+from sympy.core.function import Lambda
 from sympy.core.singleton import Singleton, S
-from sympy.core.decorators import deprecated
-from sympy.multipledispatch import dispatch
-from sympy.core.symbol import Dummy, symbols, Wild
+from sympy.core.symbol import Dummy, symbols
 from sympy.core.sympify import _sympify, sympify, converter
-from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
-                             FiniteSet, imageset)
-from sympy.sets.conditionset import ConditionSet
-from sympy.utilities.misc import filldedent, func_name
+from sympy.logic.boolalg import And
+from sympy.sets.sets import Set, Interval, Union, FiniteSet
+from sympy.utilities.misc import filldedent
 
 
 class Naturals(with_metaclass(Singleton, Set)):
@@ -41,6 +36,7 @@ class Naturals(with_metaclass(Singleton, Set)):
 
     See Also
     ========
+
     Naturals0 : non-negative integers (i.e. includes 0, too)
     Integers : also includes negative integers
     """
@@ -74,6 +70,7 @@ class Naturals0(Naturals):
 
     See Also
     ========
+
     Naturals : positive integers; does not include 0
     Integers : also includes the negative integers
     """
@@ -114,6 +111,7 @@ class Integers(with_metaclass(Singleton, Set)):
 
     See Also
     ========
+
     Naturals0 : non-negative integers
     Integers : positive and negative integers and zero
     """
@@ -215,6 +213,7 @@ class ImageSet(Set):
 
     See Also
     ========
+
     sympy.sets.sets.imageset
     """
     def __new__(cls, flambda, *sets):

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -1,10 +1,6 @@
-from sympy.core import Basic, Expr, Function, Add, Mul, Pow, Dummy, Integer
-from sympy import latex, Min, Max, Set, sympify, Lambda, symbols
-from sympy.sets import (imageset, Interval, FiniteSet, Union, ImageSet,
-        ProductSet)
+from sympy.core import Expr
 from sympy.core.decorators import call_highest_priority, _sympifyit
-from sympy.utilities.iterables import sift
-from sympy.multipledispatch import dispatch, Dispatcher
+from sympy.sets import ImageSet
 from sympy.sets.sets import set_add, set_sub, set_mul, set_div, set_pow, set_function
 
 class SetExpr(Expr):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2,28 +2,27 @@ from __future__ import print_function, division
 
 from itertools import product
 
-from sympy.core.sympify import (_sympify, sympify, converter,
-    SympifyError)
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
-from sympy.core.singleton import Singleton, S
-from sympy.core.evalf import EvalfMixin
-from sympy.core.logic import fuzzy_bool
-from sympy.core.numbers import Float
 from sympy.core.compatibility import (iterable, with_metaclass,
     ordered, range, PY3)
+from sympy.core.evalf import EvalfMixin
 from sympy.core.evaluate import global_evaluate
+from sympy.core.expr import Expr
 from sympy.core.function import FunctionClass
+from sympy.core.logic import fuzzy_bool
 from sympy.core.mul import Mul
+from sympy.core.numbers import Float
 from sympy.core.relational import Eq, Ne
+from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Symbol, Dummy, _uniquely_named_symbol
+from sympy.core.sympify import _sympify, sympify, converter
+from sympy.logic.boolalg import And, Or, Not, true, false
 from sympy.sets.contains import Contains
+from sympy.utilities import subsets
 from sympy.utilities.iterables import sift
 from sympy.utilities.misc import func_name, filldedent
+
 from mpmath import mpi, mpf
-from sympy.logic.boolalg import And, Or, Not, true, false
-from sympy.utilities import subsets
-from sympy.multipledispatch import dispatch
 
 class Set(Basic):
     """

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,6 +1,6 @@
 from sympy.sets import (ConditionSet, Intersection, FiniteSet,
     EmptySet, Union)
-from sympy import (Symbol, Eq, Lt, S, Abs, sin, pi, Lambda, Interval,
+from sympy import (Symbol, Eq, S, Abs, sin, pi, Interval,
     And, Mod, oo, Function)
 from sympy.utilities.pytest import raises
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,14 +1,14 @@
 from sympy.core.compatibility import range, PY3
 from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexRegion)
-from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
+from sympy.sets.sets import (FiniteSet, Interval, imageset, Union,
                              Intersection)
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, exp, Abs, I, Tuple, eye)
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.abc import x, y, z, t
+from sympy.abc import x, y, t
 
 import itertools
 

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -1,8 +1,7 @@
 from sympy.sets.setexpr import SetExpr
-from sympy.utilities.pytest import XFAIL
 from sympy.sets import Interval, FiniteSet, Intersection, ImageSet, Union
-from sympy import (Expr, Set, exp, log, sin, cos, Symbol, Min, Max, S, oo,
-        symbols, Lambda, sqrt, Pow, Dummy, tan, pi, Mul)
+from sympy import (Expr, Set, exp, log, cos, Symbol, Min, Max, S, oo,
+        symbols, Lambda, Dummy)
 
 I = Interval(0, 2)
 a, x = symbols("a, x")

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -822,8 +822,6 @@ def test_issue_5724_7680():
 
 
 def test_boundary():
-    x = Symbol('x', real=True)
-    y = Symbol('y', real=True)
     assert FiniteSet(1).boundary == FiniteSet(1)
     assert all(Interval(0, 1, left_open, right_open).boundary == FiniteSet(0, 1)
             for left_open in (true, false) for right_open in (true, false))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1121,7 +1121,11 @@ def test_checksol():
     assert checksol(Eq(x < 1, False), {x: 1}) is True
     assert checksol(Eq(x < 1, False), {x: 0}) is False
     assert checksol(Eq(x + 1, x**2 + 1), {x: 1}) is True
-
+    assert checksol([x - 1, x**2 - 1], x, 1) is True
+    assert checksol([x - 1, x**2 - 2], x, 1) is False
+    assert checksol(Poly(x**2 - 1), x, 1) is True
+    raises(ValueError, lambda: checksol(x, 1))
+    raises(ValueError, lambda: checksol([], x, 1))
 
 def test__invert():
     assert _invert(x - 2) == (2, x)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -164,6 +164,14 @@ def test_solve_args():
     assert solve([(x + y)**2 - 4, x + y - 2]) == [{x: -y + 2}]
     # - linear
     assert solve((x + y - 2, 2*x + 2*y - 4)) == {x: -y + 2}
+    # When one or more args are Boolean
+    assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
+    assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
+    assert not solve([Eq(x, x+1), x < 2], x)
+    assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
+    assert solve([Eq(x, x), Eq(x, x+1)], x) == []
+    assert solve(True, x) == []
+    assert solve([x-1, False], [x], set=True) == ([], set())
 
 
 def test_solve_polynomial1():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -10,7 +10,7 @@ from sympy.utilities.iterables import (
     _partition, _set_partitions, binary_partitions, bracelets, capture,
     cartes, common_prefix, common_suffix, dict_merge, filter_symbols,
     flatten, generate_bell, generate_derangements, generate_involutions,
-    generate_oriented_forest, group, has_dups, kbins, minlex, multiset,
+    generate_oriented_forest, group, has_dups, ibin, kbins, minlex, multiset,
     multiset_combinations, multiset_partitions,
     multiset_permutations, necklaces, numbered_symbols, ordered, partitions,
     permutations, postfixes, postorder_traversal, prefixes, reshape,
@@ -613,7 +613,8 @@ def test_reshape():
         (([1], 2, (3, 4)), ([5], 6, (7, 8)))
     assert reshape(list(range(12)), [2, [3], {2}, (1, (3,), 1)]) == \
         [[0, 1, [2, 3, 4], {5, 6}, (7, (8, 9, 10), 11)]]
-
+    raises(ValueError, lambda: reshape([0, 1], [-1]))
+    raises(ValueError, lambda: reshape([0, 1], [3]))
 
 def test_uniq():
     assert list(uniq(p.copy() for p in partitions(4))) == \
@@ -738,3 +739,12 @@ def test_rotations():
     assert list(rotations('ab')) == [['a', 'b'], ['b', 'a']]
     assert list(rotations(range(3))) == [[0, 1, 2], [1, 2, 0], [2, 0, 1]]
     assert list(rotations(range(3), dir=-1)) == [[0, 1, 2], [2, 0, 1], [1, 2, 0]]
+
+
+def test_ibin():
+    assert ibin(3) == [1, 1]
+    assert ibin(3, 3) == [0, 1, 1]
+    assert ibin(3, str=True) == '11'
+    assert ibin(3, 3, str=True) == '011'
+    assert list(ibin(2, 'all')) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert list(ibin(2, 'all', str=True)) == ['00', '01', '10', '11']

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -1,5 +1,5 @@
 from sympy.core.compatibility import range, unichr
-from sympy.utilities.misc import translate, replace, ordinal
+from sympy.utilities.misc import translate, replace, ordinal, rawlines
 
 def test_translate():
     abc = 'abc'
@@ -36,3 +36,8 @@ def test_ordinal():
     assert ordinal(104) == '104th'
     assert ordinal(200) == '200th'
     assert all(ordinal(i) == str(i) + 'th' for i in range(-220, -203))
+
+
+def test_rawlines():
+    assert rawlines('a a\na') == "dedent('''\\\n    a a\n    a''')"
+    assert rawlines('a a') == "'a a'"

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -6,6 +6,7 @@ from sympy.vector.vector import Vector, BaseVector, VectorAdd, \
      VectorMul, VectorZero
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.vector import Cross, Dot, dot, cross
+from sympy.utilities.pytest import raises
 
 C = CoordSys3D('C')
 
@@ -101,6 +102,8 @@ def test_vector():
     assert VectorMul(1, i) == i
     assert VectorAdd(v1, Vector.zero) == v1
     assert VectorMul(0, Vector.zero) == Vector.zero
+    raises(TypeError, lambda: v1.outer(1))
+    raises(TypeError, lambda: v1.dot(1))
 
 
 def test_vector_magnitude_normalize():
@@ -180,6 +183,8 @@ def test_vector_dot():
     assert k & j == 0
     assert k & k == 1
 
+    raises(TypeError, lambda: k.dot(1))
+
 
 def test_vector_cross():
     assert i.cross(Vector.zero) == Vector.zero
@@ -206,6 +211,8 @@ def test_vector_cross():
     assert k ^ j == -i
     assert k ^ k == Vector.zero
 
+    assert k.cross(1) == Cross(k, 1)
+
 
 def test_projection():
     v1 = i + j + k
@@ -227,3 +234,8 @@ def test_vector_diff_integrate():
             (Derivative(f(a), a))*C.i + 2*a*C.j)
     assert (Integral(v, a) == (Integral(f(a), a))*C.i +
             (Integral(a**2, a))*C.j + (Integral(-1, a))*C.k)
+
+
+def test_vector_args():
+    raises(ValueError, lambda: BaseVector(3, C))
+    raises(TypeError, lambda: BaseVector(0, Vector.zero))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
A new function refine_matrixelement(expr,assumption) has been added in the refine.py module

#### Other comments
refine() now gives the corresponding equal MatrixElement for a MatrixElement below the diagonal in a symmetric matrix 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* refine
  * added new function refine_matrixelement() for refining matrix elements of a symmetric matrix
  * added a new element " 'MatrixElement': refine_matrixelement " to handlers_dict
<!-- END RELEASE NOTES -->
